### PR TITLE
fixed-duplicate-info-id-bug

### DIFF
--- a/song-server/src/main/java/org/icgc/dcc/song/server/service/AnalysisService.java
+++ b/song-server/src/main/java/org/icgc/dcc/song/server/service/AnalysisService.java
@@ -159,6 +159,7 @@ public class AnalysisService {
     repository.deleteCompositeEntities(id);
     saveCompositeEntities(studyId, id, analysis.getSample());
     repository.deleteFiles(id);
+    analysis.getFile().forEach(f -> fileInfoService.delete(f.getObjectId()));
     saveFiles(id, studyId, analysis.getFile());
     analysisInfoService.update(id, analysis.getInfoAsString());
 

--- a/song-server/src/main/resources/data.sql
+++ b/song-server/src/main/resources/data.sql
@@ -43,5 +43,5 @@ insert into File(id, analysis_id, study_id, name, size, type, md5, access) value
 
 insert into Info(id, id_type, info) values ('FI1', 'File', '{"name":"file1"}' );
 insert into Info(id, id_type, info) values ('FI2', 'File', '{"name":"file2"}' );
-insert into Info(id, id_type, info) values ('FI2', 'File', '{"name":"file3"}' );
+insert into Info(id, id_type, info) values ('FI3', 'File', '{"name":"file3"}' );
 insert into Info(id, id_type, info) values ('FI4', 'File', '{"name":"file4"}' );


### PR DESCRIPTION
Since there is no primary unique key restraint on any field in the info table, you can have 2 rows with the same info.id and info.id_type fields. It seems like this was never caught before, and now that the info_id_id_type_uindex has been applied, it catches it. The bug was during the update phase of an analysis. When updating an analysis, the files are deleted and then recreated. The file_ids from the info.id table were not deleted, so when an update was made, postgres saw it as a duplicate.

There was also an issue with the data.sql which was a typo. Again, only catchable now that the index for info_id_id_type_uindex is defined.