### PR TITLE
fix(Revert): changed back to json type instead of jsonb

### DIFF
--- a/song-server/src/main/resources/schema.sql
+++ b/song-server/src/main/resources/schema.sql
@@ -162,7 +162,7 @@ DROP TABLE IF EXISTS Info;
 CREATE TABLE Info (
   id              VARCHAR(36),
   id_type         id_type,
-  info            jsonb
+  info            json
 );
 
 


### PR DESCRIPTION
Since most operations will be simply reading and writing json data to the info field of the Info
table, storing a jsonb format takes up a slightly more space and must be transformed to text during
reads. Since most features simply read the entire field, using the json format makes more sense than
jsonb

Note versions 0.x.x were originally `json` and version 1.0.0 changed it to `jsonb`. The purpose of this PR is to revert that.