### PR TITLE
Fix path for example.

### DIFF
--- a/song-docker/example/exampleVariantCall.json
+++ b/song-docker/example/exampleVariantCall.json
@@ -41,7 +41,7 @@
   ],
   "file": [
     {
-      "fileName": "../example/example.vcf.gz",
+      "fileName": "example/example.vcf.gz",
       "fileSize": 52,
       "fileMd5sum": "9a793e90d0d1e11301ea8da996446e59",
       "fileAccess" : "open",
@@ -53,7 +53,7 @@
       }
     },
     {
-      "fileName": "../example/example.vcf.gz.idx",
+      "fileName": "example/example.vcf.gz.idx",
       "fileSize": 25,
       "fileMd5sum": "c03274816eb4907a92b8e5632cd6eb81",
       "fileAccess" : "open",


### PR DESCRIPTION
Example file path is not correct in exampleVariantCall.json. this will fix the
example manifest generation.