### PR TITLE
added longer default retry for the id client

### DIFF
--- a/song-server/src/main/resources/application.yml
+++ b/song-server/src/main/resources/application.yml
@@ -55,6 +55,9 @@ id:
   authToken: "idToken"
   realIds: false
   persistInMemory: false
+  maxRetries: 10
+  multiplier: 2
+  initialBackoffSeconds: 2
 
 validation:
   delayMs: 30


### PR DESCRIPTION
tested using Docker for Song, by starting all services except the Id service. Made song-server do a save, and watched the id-client retry a few times. After 2 or 3 retries (was able to see the realtime log output), i started the id service backup, and the id client then retried successfully and then the upload was saved by song. 

This is related to icgc-dcc/dcc-id#17 and accompanies icgc-dcc/dcc-id#18