### PR TITLE
Feature/song 338 get analyses optimize

### DIFF
--- a/song-server/src/main/java/bio/overture/song/server/controller/AnalysisController.java
+++ b/song-server/src/main/java/bio/overture/song/server/controller/AnalysisController.java
@@ -82,7 +82,7 @@ public class AnalysisController {
       @PathVariable("studyId") String studyId,
       @ApiParam(value = "Non-empty comma separated list of analysis states to filter by")
       @RequestParam(value = "analysisStates", defaultValue = "PUBLISHED", required = false) String analysisStates) {
-    return analysisService.getAnalysis(studyId, ImmutableSet.copyOf(COMMA.split(analysisStates)) );
+    return analysisService.getAnalysisByView(studyId, ImmutableSet.copyOf(COMMA.split(analysisStates)) );
   }
 
   /**

--- a/song-server/src/main/java/bio/overture/song/server/converter/FullViewConverter.java
+++ b/song-server/src/main/java/bio/overture/song/server/converter/FullViewConverter.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2018. Ontario Institute for Cancer Research
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package bio.overture.song.server.converter;
+
+import bio.overture.song.server.model.analysis.AbstractAnalysis;
+import bio.overture.song.server.model.entity.Donor;
+import bio.overture.song.server.model.entity.FileEntity;
+import bio.overture.song.server.model.entity.FullView;
+import bio.overture.song.server.model.entity.Sample;
+import bio.overture.song.server.model.entity.Specimen;
+import bio.overture.song.server.model.entity.composites.CompositeEntity;
+import bio.overture.song.server.model.enums.AnalysisTypes;
+import com.google.common.collect.ImmutableList;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.val;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.groupingBy;
+import static lombok.AccessLevel.PRIVATE;
+import static org.icgc.dcc.common.core.util.stream.Collectors.toImmutableSet;
+import static bio.overture.song.core.utils.JsonUtils.toJsonNode;
+import static bio.overture.song.server.model.enums.AnalysisTypes.resolveAnalysisType;
+
+/**
+ * Contains methods for converting FullView entities into fully populated SequencingReadAnalyses
+ * or VariantCallAnalyses
+ */
+@NoArgsConstructor(access = PRIVATE)
+public class FullViewConverter {
+
+  /**
+   * Converts a list of FullView entities to a fully populated SequencingReadAnalysis or VariantCallAnalysis object map.
+   * This method basically takes a flattened analysis (aka FullView) and converts it
+   * to a fully populated analysis object map.
+   * @param fullViewEntities List of FullView entities
+   * @param analysisType the AnalysisType to filter on
+   * @param analysisInstantiatorCallback callback that instantiates the correct analysis object
+   * @return list of abstract analyses of the specified analysis type
+   */
+  public static List<AbstractAnalysis> processAnalysisForType(@NonNull List<FullView> fullViewEntities,
+      @NonNull AnalysisTypes analysisType, @NonNull Function<String, AbstractAnalysis> analysisInstantiatorCallback){
+
+    // Ensure only processing fullView entities of specified analysisType
+    val analysisIdMap = fullViewEntities.stream()
+        .filter(x -> analysisType == resolveAnalysisType(x.getAnalysisType()))
+        .collect(groupingBy(FullView::getAnalysisId));
+
+    val outputList = ImmutableList.<AbstractAnalysis>builder();
+
+    for (val analysisIdEntry : analysisIdMap.entrySet()){
+      val analysisId = analysisIdEntry.getKey();
+      val analysisIdResults = analysisIdEntry.getValue();
+
+      val firstAnalysis = analysisIdResults.get(0);
+      val analysisState = firstAnalysis.getAnalysisState();
+      val analysisInfo = toJsonNode(firstAnalysis.getAnalysisInfo());
+      val studyId = firstAnalysis.getStudyId();
+
+      val a = analysisInstantiatorCallback.apply(analysisType.toString());
+      a.setAnalysisId(analysisId);
+      a.setAnalysisState(analysisState);
+      a.setStudy(studyId);
+      a.setInfo(analysisInfo);
+
+      val files = extractFiles(analysisIdResults);
+      a.setFile(files);
+
+      val compositeEntites = extractCompositeEntities(analysisIdResults);
+      a.setSample(compositeEntites);
+      outputList.add(a);
+    }
+    return outputList.build();
+  }
+
+  private static <T,R> Set<R> transformImmutableSet(List<T> list, Function<T, R> trFunction){
+    return list.stream()
+        .map(trFunction)
+        .collect(toImmutableSet());
+  }
+
+  private static FileEntity extractFile(FullView fullView){
+    val f = FileEntity.builder()
+        .analysisId(fullView.getAnalysisId())
+        .fileAccess(fullView.getFileAccess())
+        .fileMd5sum(fullView.getFileMd5())
+        .fileName(fullView.getFileName())
+        .fileSize(fullView.getFileSize())
+        .fileType(fullView.getFileType())
+        .objectId(fullView.getFileObjectId())
+        .studyId(fullView.getStudyId())
+        .build();
+    f.setInfo(toJsonNode(fullView.getFileInfo()));
+    return f;
+  }
+
+  private static List<FileEntity> extractFiles(List<FullView> fullViews){
+    return ImmutableList.copyOf(transformImmutableSet(fullViews, FullViewConverter::extractFile));
+  }
+
+  private static Sample extractSample(FullView fullView){
+    val s = Sample.builder()
+        .sampleId(fullView.getSampleId())
+        .sampleSubmitterId(fullView.getSampleSubmitterId())
+        .sampleType(fullView.getSampleType())
+        .specimenId(fullView.getSpecimenId())
+        .build();
+    s.setInfo(toJsonNode(fullView.getSampleInfo()));
+    return s;
+  }
+
+  private static Specimen extractSpecimen(FullView fullView){
+    val s = Specimen.builder()
+        .specimenId(fullView.getSpecimenId())
+        .specimenSubmitterId(fullView.getSpecimenSubmitterId())
+        .specimenType(fullView.getSpecimenType())
+        .specimenClass(fullView.getSpecimenClass())
+        .donorId(fullView.getDonorId())
+        .build();
+    s.setInfo(toJsonNode(fullView.getSpecimenInfo()));
+    return s;
+  }
+
+  private static Donor extractDonor(FullView fullView){
+    val d = Donor.builder()
+        .donorId(fullView.getDonorId())
+        .studyId(fullView.getStudyId())
+        .donorSubmitterId(fullView.getDonorSubmitterId())
+        .donorGender(fullView.getDonorGender())
+        .build();
+    d.setInfo(toJsonNode(fullView.getDonorInfo()));
+    return d;
+  }
+
+  private static Optional<Specimen> extractSpecimenForSample(List<FullView> fullViews, String sampleId){
+    return fullViews.stream()
+        .filter(x -> x.getSampleId().equals(sampleId))
+        .map(FullViewConverter::extractSpecimen)
+        .findFirst();
+  }
+
+  private static Optional<Donor> extractDonorForSpecimen(List<FullView> fullViews, String specimenId){
+    return fullViews.stream()
+        .filter(x -> x.getSpecimenId().equals(specimenId))
+        .map(FullViewConverter::extractDonor)
+        .findFirst();
+  }
+
+  private static List<CompositeEntity> extractCompositeEntities(List<FullView> fullViews){
+    val samples = extractSamples(fullViews);
+    val list = ImmutableList.<CompositeEntity>builder();
+    for (val sample : samples){
+      val specimen = extractSpecimenForSample(fullViews, sample.getSampleId())
+          .orElseThrow(() -> new IllegalStateException(
+              format("The specimen '%s' for sampleId '%s' does not exist in the list of FullView entities",
+                  sample.getSpecimenId(), sample.getSampleId())));
+
+      val donor = extractDonorForSpecimen(fullViews, specimen.getSpecimenId())
+          .orElseThrow(() -> new IllegalStateException(
+              format("The donor '%s' for specimenId '%s' does not exist in the list of FullView entities",
+                  specimen.getDonorId(), specimen.getSpecimenId())));
+      val c = new CompositeEntity();
+      c.setDonor(donor);
+      c.setSpecimen(specimen);
+      c.setWithSample(sample);
+      list.add(c);
+    }
+    return list.build();
+  }
+
+  private static List<Sample> extractSamples(List<FullView> fullViews){
+    return ImmutableList.copyOf(transformImmutableSet(fullViews, FullViewConverter::extractSample));
+  }
+
+}

--- a/song-server/src/main/java/bio/overture/song/server/model/entity/FullView.java
+++ b/song-server/src/main/java/bio/overture/song/server/model/entity/FullView.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2018. Ontario Institute for Cancer Research
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package bio.overture.song.server.model.entity;
+
+import bio.overture.song.server.model.enums.TableNames;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.Immutable;
+import org.hibernate.annotations.Type;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.Map;
+
+import static bio.overture.song.server.repository.CustomJsonType.CUSTOM_JSON_TYPE_PKG_PATH;
+
+@Entity
+@Immutable
+@Table(name = TableNames.FULL_VIEW)
+@Data
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class FullView {
+
+  public static final String FILE_OBJECT_ID																	= "file_object_id";
+  public static final String FILE_ACCESS																		= "file_access";
+  public static final String FILE_MD5																				= "file_md5";
+  public static final String FILE_SIZE																			= "file_size";
+  public static final String FILE_NAME																			= "file_name";
+  public static final String FILE_TYPE																			= "file_type";
+  public static final String FILE_INFO																			= "file_info";
+  public static final String SAMPLE_ID																			= "sample_id";
+  public static final String SAMPLE_TYPE																		= "sample_type";
+  public static final String SAMPLE_SUBMITTER_ID														= "sample_submitter_id";
+  public static final String SAMPLE_INFO																		= "sample_info";
+  public static final String SPECIMEN_ID																		= "specimen_id";
+  public static final String SPECIMEN_TYPE																	= "specimen_type";
+  public static final String SPECIMEN_CLASS																	= "specimen_class";
+  public static final String SPECIMEN_SUBMITTER_ID													= "specimen_submitter_id";
+  public static final String SPECIMEN_INFO																	= "specimen_info";
+  public static final String DONOR_ID																				= "donor_id";
+  public static final String DONOR_GENDER																		= "donor_gender";
+  public static final String DONOR_SUBMITTER_ID															= "donor_submitter_id";
+  public static final String DONOR_INFO																			= "donor_info";
+  public static final String SEQUENCINGREAD_LIBRARY_STRATEGY								= "sequencingread_library_strategy";
+  public static final String SEQUENCINGREAD_ALIGNED													= "sequencingread_aligned";
+  public static final String SEQUENCINGREAD_ALIGNMENT_TOOL									= "sequencingread_alignment_tool";
+  public static final String SEQUENCINGREAD_INSERT_SIZE											= "sequencingread_insert_size";
+  public static final String SEQUENCINGREAD_PAIRED_END											= "sequencingread_paired_end";
+  public static final String SEQUENCINGREAD_REFERENCE_GENOME								= "sequencingread_reference_genome";
+  public static final String SEQUENCINGREAD_INFO														= "sequencingread_info";
+  public static final String VARIANTCALL_VARIANT_CALLING_TOOL								= "variantcall_variant_calling_tool";
+  public static final String VARIANTCALL_MATCHED_NORMAL_SAMPLE_SUBMITTER_ID	= "variantcall_matched_normal_sample_submitter_id";
+  public static final String VARIANTCALL_TUMOUR_SAMPLE_SUBMITTER_ID					= "variantcall_tumour_sample_submitter_id";
+  public static final String VARIANTCALL_INFO																= "variantcall_info";
+  public static final String ANALYSIS_ID																		= "analysis_id";
+  public static final String ANALYSIS_TYPE																	= "analysis_type";
+  public static final String ANALYSIS_STATE																	= "analysis_state";
+  public static final String ANALYSIS_INFO																	= "analysis_info";
+  public static final String STUDY_ID																				= "study_id";
+
+  /**
+   * File Entity
+   */
+  @Id
+  @Column(name = FILE_OBJECT_ID)
+  private String fileObjectId;
+
+  @Column(name = FILE_ACCESS)
+  private String fileAccess;
+
+  @Column(name = FILE_MD5)
+  private String fileMd5;
+
+  @Column(name = FILE_NAME)
+  private String fileName;
+
+  @Column(name = FILE_SIZE)
+  private Long fileSize;
+
+  @Column(name = FILE_TYPE)
+  private String fileType;
+
+  @Column(name = FILE_INFO)
+  @Type(type = CUSTOM_JSON_TYPE_PKG_PATH)
+  private Map<String, Object> fileInfo;
+
+  /**
+   * Sample Entity
+   */
+  @Column(name = SAMPLE_ID)
+  private String sampleId;
+
+  @Column(name = SAMPLE_SUBMITTER_ID)
+  private String sampleSubmitterId;
+
+  @Column(name = SAMPLE_TYPE)
+  private String sampleType;
+
+  @Column(name = SAMPLE_INFO)
+  @Type(type = CUSTOM_JSON_TYPE_PKG_PATH)
+  private Map<String, Object> sampleInfo;
+
+  /**
+   * Specimen Entity
+   */
+  @Column(name = SPECIMEN_ID)
+  private String specimenId;
+
+  @Column(name = SPECIMEN_SUBMITTER_ID)
+  private String specimenSubmitterId;
+
+  @Column(name = SPECIMEN_TYPE)
+  private String specimenType;
+
+  @Column(name = SPECIMEN_CLASS)
+  private String specimenClass;
+
+  @Column(name = SPECIMEN_INFO)
+  @Type(type = CUSTOM_JSON_TYPE_PKG_PATH)
+  private Map<String, Object> specimenInfo;
+
+  /**
+   * Donor Entity
+   */
+  @Column(name = DONOR_ID)
+  private String donorId;
+
+  @Column(name = DONOR_SUBMITTER_ID)
+  private String donorSubmitterId;
+
+  @Column(name = DONOR_GENDER)
+  private String donorGender;
+
+  @Column(name = DONOR_INFO)
+  @Type(type = CUSTOM_JSON_TYPE_PKG_PATH)
+  private Map<String, Object> donorInfo;
+
+  /**
+   * Analysis Entity
+   */
+  @Column(name = ANALYSIS_ID)
+  private String analysisId;
+
+  @Column(name = ANALYSIS_TYPE)
+  private String analysisType;
+
+  @Column(name = ANALYSIS_STATE)
+  private String analysisState;
+
+  @Column(name = ANALYSIS_INFO)
+  @Type(type = CUSTOM_JSON_TYPE_PKG_PATH)
+  private Map<String, Object> analysisInfo;
+
+  /**
+   * Study Entity
+   */
+  @Column(name = STUDY_ID)
+  private String studyId;
+
+}

--- a/song-server/src/main/java/bio/overture/song/server/model/enums/TableNames.java
+++ b/song-server/src/main/java/bio/overture/song/server/model/enums/TableNames.java
@@ -37,5 +37,6 @@ public class TableNames {
  public static final String INFO = "Info";
  public static final String BUSINESS_KEY_VIEW = "Businesskeyview";
  public static final String ID_VIEW = "Idview";
+ public static final String FULL_VIEW = "Fullview";
 
 }

--- a/song-server/src/main/java/bio/overture/song/server/repository/FullViewRepository.java
+++ b/song-server/src/main/java/bio/overture/song/server/repository/FullViewRepository.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018. Ontario Institute for Cancer Research
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package bio.overture.song.server.repository;
+
+import bio.overture.song.server.model.entity.FullView;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FullViewRepository extends JpaRepository<FullView, String> {
+
+  List<FullView> findAllByAnalysisIdIn(List<String> analysisIds);
+  List<FullView> findAllByStudyIdAndAnalysisStateIn(String studyId, List<String> analysisStates);
+
+}

--- a/song-server/src/main/java/bio/overture/song/server/repository/InfoRepository.java
+++ b/song-server/src/main/java/bio/overture/song/server/repository/InfoRepository.java
@@ -20,7 +20,10 @@ import bio.overture.song.server.model.entity.Info;
 import bio.overture.song.server.model.entity.InfoPK;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface InfoRepository extends JpaRepository<Info, InfoPK>{
 
+  List<Info> findAllByInfoPKIn(List<InfoPK> infoPKS);
 
 }

--- a/song-server/src/main/java/bio/overture/song/server/repository/SequencingReadRepository.java
+++ b/song-server/src/main/java/bio/overture/song/server/repository/SequencingReadRepository.java
@@ -20,6 +20,10 @@ package bio.overture.song.server.repository;
 import bio.overture.song.server.model.experiment.SequencingRead;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface SequencingReadRepository extends JpaRepository<SequencingRead, String>{
+
+  List<SequencingRead> findAllByAnalysisIdIn(List<String> analysisIds);
 
 }

--- a/song-server/src/main/java/bio/overture/song/server/repository/VariantCallRepository.java
+++ b/song-server/src/main/java/bio/overture/song/server/repository/VariantCallRepository.java
@@ -20,6 +20,10 @@ package bio.overture.song.server.repository;
 import bio.overture.song.server.model.experiment.VariantCall;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface VariantCallRepository extends JpaRepository<VariantCall, String> {
+
+  List<VariantCall> findAllByAnalysisIdIn(List<String> analysisIds);
 
 }

--- a/song-server/src/main/java/bio/overture/song/server/service/AnalysisService.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/AnalysisService.java
@@ -28,6 +28,7 @@ import bio.overture.song.server.model.analysis.SequencingReadAnalysis;
 import bio.overture.song.server.model.analysis.VariantCallAnalysis;
 import bio.overture.song.server.model.entity.FileEntity;
 import bio.overture.song.server.model.entity.composites.CompositeEntity;
+import bio.overture.song.server.model.enums.AnalysisTypes;
 import bio.overture.song.server.model.enums.Constants;
 import bio.overture.song.server.model.experiment.SequencingRead;
 import bio.overture.song.server.model.experiment.VariantCall;
@@ -587,10 +588,13 @@ public class AnalysisService {
     val srMap = sequencingReadRepository.findAllByAnalysisIdIn(newArrayList(analysisIds))
         .stream()
         .collect(toMap(SequencingRead::getAnalysisId, x->x));
+    val srInfoMap = sequencingReadInfoService.getInfoMap(analysisIds);
 
     analyses.forEach(x -> {
       SequencingReadAnalysis sra = (SequencingReadAnalysis)x;
-      sra.setExperiment(srMap.get(x.getAnalysisId()));
+      SequencingRead sr = srMap.get(x.getAnalysisId());
+      sr.setInfo(srInfoMap.get(x.getAnalysisId()));
+      sra.setExperiment(sr);
     });
   }
 
@@ -602,9 +606,14 @@ public class AnalysisService {
     val vcMap = variantCallRepository.findAllByAnalysisIdIn(newArrayList(analysisIds))
         .stream()
         .collect(toMap(VariantCall::getAnalysisId, x->x));
+
+    val vcInfoMap = variantCallInfoService.getInfoMap(analysisIds);
+
     analyses.forEach(x -> {
       VariantCallAnalysis vca = (VariantCallAnalysis)x;
-      vca.setExperiment(vcMap.get(x.getAnalysisId()));
+      VariantCall vc = vcMap.get(x.getAnalysisId());
+      vc.setInfo(vcInfoMap.get(x.getAnalysisId()));
+      vca.setExperiment(vc);
     });
   }
 

--- a/song-server/src/main/java/bio/overture/song/server/service/AnalysisService.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/AnalysisService.java
@@ -26,13 +26,8 @@ import bio.overture.song.server.model.analysis.AbstractAnalysis;
 import bio.overture.song.server.model.analysis.Analysis;
 import bio.overture.song.server.model.analysis.SequencingReadAnalysis;
 import bio.overture.song.server.model.analysis.VariantCallAnalysis;
-import bio.overture.song.server.model.entity.Donor;
 import bio.overture.song.server.model.entity.FileEntity;
-import bio.overture.song.server.model.entity.FullView;
-import bio.overture.song.server.model.entity.Sample;
-import bio.overture.song.server.model.entity.Specimen;
 import bio.overture.song.server.model.entity.composites.CompositeEntity;
-import bio.overture.song.server.model.enums.AnalysisTypes;
 import bio.overture.song.server.model.enums.Constants;
 import bio.overture.song.server.model.experiment.SequencingRead;
 import bio.overture.song.server.model.experiment.VariantCall;
@@ -65,12 +60,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toMap;
 import static org.icgc.dcc.common.core.util.Joiners.COMMA;
 import static org.icgc.dcc.common.core.util.stream.Collectors.toImmutableList;
 import static org.icgc.dcc.common.core.util.stream.Collectors.toImmutableMap;
@@ -84,6 +80,7 @@ import static bio.overture.song.core.exceptions.ServerErrors.MALFORMED_PARAMETER
 import static bio.overture.song.core.exceptions.ServerErrors.MISMATCHING_STORAGE_OBJECT_CHECKSUMS;
 import static bio.overture.song.core.exceptions.ServerErrors.MISMATCHING_STORAGE_OBJECT_SIZES;
 import static bio.overture.song.core.exceptions.ServerErrors.MISSING_STORAGE_OBJECTS;
+import static bio.overture.song.core.exceptions.ServerErrors.NOT_IMPLEMENTED_YET;
 import static bio.overture.song.core.exceptions.ServerErrors.SEQUENCING_READ_NOT_FOUND;
 import static bio.overture.song.core.exceptions.ServerErrors.UNKNOWN_ERROR;
 import static bio.overture.song.core.exceptions.ServerErrors.VARIANT_CALL_NOT_FOUND;
@@ -94,10 +91,12 @@ import static bio.overture.song.core.model.enums.AnalysisStates.SUPPRESSED;
 import static bio.overture.song.core.model.enums.AnalysisStates.UNPUBLISHED;
 import static bio.overture.song.core.model.enums.AnalysisStates.findIncorrectAnalysisStates;
 import static bio.overture.song.core.utils.JsonUtils.toJson;
-import static bio.overture.song.core.utils.JsonUtils.toJsonNode;
 import static bio.overture.song.core.utils.Responses.ok;
+import static bio.overture.song.server.converter.FullViewConverter.processAnalysisForType;
 import static bio.overture.song.server.kafka.AnalysisMessage.createAnalysisMessage;
 import static bio.overture.song.server.model.enums.AnalysisTypes.SEQUENCING_READ;
+import static bio.overture.song.server.model.enums.AnalysisTypes.VARIANT_CALL;
+import static bio.overture.song.server.model.enums.AnalysisTypes.resolveAnalysisType;
 import static bio.overture.song.server.repository.search.SearchTerm.createMultiSearchTerms;
 
 @Slf4j
@@ -111,7 +110,7 @@ public class AnalysisService {
   private static final Map<String, Class<? extends AbstractAnalysis>> ANALYSIS_CLASS_MAP =
       new HashMap<String, Class<? extends AbstractAnalysis>>(){{
         put(SEQUENCING_READ.toString(), SequencingReadAnalysis.class);
-        put(AnalysisTypes.VARIANT_CALL.toString(), VariantCallAnalysis.class);
+        put(VARIANT_CALL.toString(), VariantCallAnalysis.class);
       }};
 
   @Autowired
@@ -214,147 +213,66 @@ public class AnalysisService {
     return ok("AnalysisId %s was updated successfully", analysis.getAnalysisId());
   }
 
-  private static <T,R> Set<R> transformImmutableSet(List<T> list, Function<T, R> trFunction){
-    return list.stream()
-        .map(trFunction)
-        .collect(toImmutableSet());
-  }
-
-  private static  FileEntity extractFile(FullView fullView){
-    val f = FileEntity.builder()
-        .analysisId(fullView.getAnalysisId())
-        .fileAccess(fullView.getFileAccess())
-        .fileMd5sum(fullView.getFileMd5())
-        .fileName(fullView.getFileName())
-        .fileSize(fullView.getFileSize())
-        .fileType(fullView.getFileType())
-        .objectId(fullView.getFileObjectId())
-        .studyId(fullView.getStudyId())
-        .build();
-    f.setInfo(toJsonNode(fullView.getFileInfo()));
-    return f;
-  }
-
-  private static List<FileEntity> extractFiles(List<FullView> fullViews){
-    return ImmutableList.copyOf(transformImmutableSet(fullViews, AnalysisService::extractFile));
-  }
-
-  private static Sample extractSample(FullView fullView){
-    val s = Sample.builder()
-        .sampleId(fullView.getSampleId())
-        .sampleSubmitterId(fullView.getSampleSubmitterId())
-        .sampleType(fullView.getSampleType())
-        .specimenId(fullView.getSpecimenId())
-        .build();
-    s.setInfo(toJsonNode(fullView.getSampleInfo()));
-    return s;
-  }
-
-  private static Specimen extractSpecimen(FullView fullView){
-    val s = Specimen.builder()
-        .specimenId(fullView.getSpecimenId())
-        .specimenSubmitterId(fullView.getSpecimenSubmitterId())
-        .specimenType(fullView.getSpecimenType())
-        .specimenClass(fullView.getSpecimenClass())
-        .donorId(fullView.getDonorId())
-        .build();
-    s.setInfo(toJsonNode(fullView.getSpecimenInfo()));
-    return s;
-  }
-
-  private static Donor extractDonor(FullView fullView){
-    val d = Donor.builder()
-        .donorId(fullView.getDonorId())
-        .studyId(fullView.getStudyId())
-        .donorSubmitterId(fullView.getDonorSubmitterId())
-        .donorGender(fullView.getDonorGender())
-        .build();
-    d.setInfo(toJsonNode(fullView.getDonorInfo()));
-    return d;
-  }
-
-  private static List<Donor> extractDonors(List<FullView> fullViews){
-    return ImmutableList.copyOf(transformImmutableSet(fullViews, AnalysisService::extractDonor));
-  }
-
-  private static Optional<Specimen> extractSpecimenForSample(List<FullView> fullViews, String sampleId){
-    return fullViews.stream()
-        .filter(x -> x.getSampleId().equals(sampleId))
-        .map(AnalysisService::extractSpecimen)
-        .findFirst();
-  }
-
-  private static Optional<Donor> extractDonorForSpecimen(List<FullView> fullViews, String specimenId){
-    return fullViews.stream()
-        .filter(x -> x.getSpecimenId().equals(specimenId))
-        .map(AnalysisService::extractDonor)
-        .findFirst();
-  }
-
-  private static List<Specimen> extractSpecimens(List<FullView> fullViews){
-    return ImmutableList.copyOf(transformImmutableSet(fullViews, AnalysisService::extractSpecimen));
-  }
-
-  private static List<CompositeEntity> extractCompositeEntities(List<FullView> fullViews){
-    val samples = extractSamples(fullViews);
-    val list = ImmutableList.<CompositeEntity>builder();
-    for (val sample : samples){
-      val specimen = extractSpecimenForSample(fullViews, sample.getSampleId())
-          .orElseThrow(() -> new IllegalStateException(
-              format("The specimen '%s' for sampleId '%s' does not exist",
-                  sample.getSpecimenId(), sample.getSampleId())));
-
-      val donor = extractDonorForSpecimen(fullViews, specimen.getSpecimenId())
-          .orElseThrow(() -> new IllegalStateException(
-              format("The donor '%s' for specimenId '%s' does not exist",
-                  specimen.getDonorId(), specimen.getSpecimenId())));
-      val c = new CompositeEntity();
-      c.setDonor(donor);
-      c.setSpecimen(specimen);
-      c.setWithSample(sample);
-      list.add(c);
-    }
-    return list.build();
-  }
-
-  private static List<Sample> extractSamples(List<FullView> fullViews){
-    return ImmutableList.copyOf(transformImmutableSet(fullViews, AnalysisService::extractSample));
-  }
-
-  public List<AbstractAnalysis> getAnalysis2(@NonNull String studyId, @NonNull Set<String> analysisStates) {
-    studyService.checkStudyExist(studyId);
-
+  private static Set<String> resolveSelectedAnalysisStates(Set<String> analysisStates){
     Set<String> finalStates = DEFAULT_ANALYSIS_STATES;
     if (!analysisStates.isEmpty()) {
       val errorSet = findIncorrectAnalysisStates(analysisStates);
-      checkServer(errorSet.isEmpty(), getClass(), MALFORMED_PARAMETER,
+      checkServer(errorSet.isEmpty(), AnalysisService.class, MALFORMED_PARAMETER,
           "The following are not AnalysisStates: '%s'", Joiner.on("', '").join(errorSet) );
       finalStates = analysisStates;
     }
+    return ImmutableSet.copyOf(finalStates);
+  }
 
+  private void processSequencingReadsInPlace(List<AbstractAnalysis> analyses){
+    val analysisIds = analyses.stream()
+        .map(AbstractAnalysis::getAnalysisId)
+        .collect(toImmutableSet());
+    val srMap = sequencingReadRepository.findAllByAnalysisIdIn(newArrayList(analysisIds))
+        .stream()
+        .collect(toMap(SequencingRead::getAnalysisId, x->x));
+
+    analyses.forEach(x -> {
+      SequencingReadAnalysis sra = (SequencingReadAnalysis)x;
+      sra.setExperiment(srMap.get(x.getAnalysisId()));
+    });
+  }
+
+  private void processVariantCallsInPlace(List<AbstractAnalysis> analyses){
+    val analysisIds = analyses.stream()
+        .map(AbstractAnalysis::getAnalysisId)
+        .collect(toImmutableSet());
+
+    val vcMap = variantCallRepository.findAllByAnalysisIdIn(newArrayList(analysisIds))
+        .stream()
+        .collect(toMap(VariantCall::getAnalysisId, x->x));
+    analyses.forEach(x -> {
+      VariantCallAnalysis vca = (VariantCallAnalysis)x;
+      vca.setExperiment(vcMap.get(x.getAnalysisId()));
+    });
+  }
+
+  public List<AbstractAnalysis> getAnalysisByView(@NonNull String studyId, @NonNull Set<String> analysisStates) {
+    studyService.checkStudyExist(studyId);
+    val finalStates = resolveSelectedAnalysisStates(analysisStates);
     val results = fullViewRepository.findAllByStudyIdAndAnalysisStateIn(studyId, ImmutableList.copyOf(finalStates));
-    val analysisMap = results.stream().collect(groupingBy(FullView::getAnalysisId));
+    val analysisTypeMap = results.stream().collect(groupingBy(x -> resolveAnalysisType(x.getAnalysisType())));
     val outputList = ImmutableList.<AbstractAnalysis>builder();
-    for (val analysisEntry : analysisMap.entrySet()){
-      val rows = analysisEntry.getValue();
-      val first = rows.get(0);
-      val analysisId = analysisEntry.getKey();
-      val analysisState = first.getAnalysisState();
-      val analysisType = first.getAnalysisType();
-      val analysisInfo = toJsonNode(first.getAnalysisInfo());
 
-      val a = instantiateAnalysis(analysisType);
-      a.setAnalysisId(analysisId);
-      a.setAnalysisState(analysisState);
-      a.setStudy(studyId);
-      a.setInfo(analysisInfo);
+    for (val analysisTypeEntry : analysisTypeMap.entrySet()){
+      val analysisType = analysisTypeEntry.getKey();
+      val analysisTypeResults = analysisTypeEntry.getValue();
+      val analysesForType = processAnalysisForType(analysisTypeResults, analysisType, AnalysisService::instantiateAnalysis);
 
-      val files = extractFiles(rows);
-      a.setFile(files);
-
-      val compositeEntites = extractCompositeEntities(rows);
-      a.setSample(compositeEntites);
-      outputList.add(a);
+      if (analysisType == SEQUENCING_READ){
+        processSequencingReadsInPlace(analysesForType);
+      } else if (analysisType == VARIANT_CALL){
+        processVariantCallsInPlace(analysesForType);
+      } else {
+        throw buildServerException(getClass(), NOT_IMPLEMENTED_YET,
+            "The analysisType '%s' has not been implemented yet", analysisType);
+      }
+      outputList.addAll(analysesForType);
     }
     return outputList.build();
   }

--- a/song-server/src/main/java/bio/overture/song/server/service/export/ExportService.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/export/ExportService.java
@@ -22,7 +22,6 @@ import bio.overture.song.core.model.enums.AnalysisStates;
 import bio.overture.song.server.model.analysis.AbstractAnalysis;
 import bio.overture.song.server.model.analysis.SequencingReadAnalysis;
 import bio.overture.song.server.model.analysis.VariantCallAnalysis;
-import bio.overture.song.server.model.enums.AnalysisTypes;
 import bio.overture.song.server.service.AnalysisService;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
@@ -72,7 +71,7 @@ public class ExportService {
   @SneakyThrows
   public List<ExportedPayload> exportPayloadsForStudy(@NonNull String studyId,
       boolean includeAnalysisId){
-    val payloads = analysisService.getAnalysis(studyId, ALL_ANALYSIS_STATES).stream()
+    val payloads = analysisService.getAnalysisByView(studyId, ALL_ANALYSIS_STATES).stream()
         .map(x -> convertToPayload(x, includeAnalysisId))
         .collect(toImmutableList());
     return ImmutableList.of(createExportedPayload(studyId, payloads));

--- a/song-server/src/main/resources/schema.sql
+++ b/song-server/src/main/resources/schema.sql
@@ -220,6 +220,51 @@ CREATE VIEW IdView AS
     INNER JOIN File as F on SAS.analysis_id = F.analysis_id
     INNER JOIN Analysis as A on SAS.analysis_id = A.id;
 
+
+CREATE VIEW FullView AS
+SELECT
+       A.id as analysis_id,
+       A.study_id as study_id,
+       A.type as analysis_type,
+       A.state as analysis_state,
+       I_A.info as analysis_info,
+       F.id as file_object_id,
+       F.access as file_access,
+       F.md5 as file_md5,
+       F.name as file_name,
+       F.size as file_size,
+       F.type as file_type,
+       I_F.info as file_info,
+       SA.id as sample_id,
+       SA.type as sample_type,
+       SA.submitter_id as sample_submitter_id,
+       I_SA.info as sample_info,
+       SP.id as specimen_id,
+       SP.type as specimen_type,
+       SP.class as specimen_class,
+       SP.submitter_id as specimen_submitter_id,
+       I_SP.info as specimen_info,
+       D.id as donor_id,
+       D.gender as donor_gender,
+       D.submitter_id as donor_submitter_id,
+       I_D.info as donor_info,
+       I_SR.info as sequencingread_info,
+       I_VC.info as variantcall_info
+from Analysis A
+       left join Info I_A on I_A.id = A.id and I_A.id_type = 'Analysis'
+       left join File F on F.analysis_id = A.id
+       left join Info I_F on I_F.id = F.id and I_F.id_type = 'File'
+       left join SampleSet SS on SS.analysis_id = A.id
+       left join Sample SA on SA.id = SS.sample_id
+       left join Info I_SA on I_SA.id = SA.id and I_SA.id_type = 'Sample'
+       left join Specimen SP on SP.id = SA.specimen_id
+       left join Info I_SP on I_SP.id = SP.id and I_SP.id_type = 'Specimen'
+       left join Donor D on D.id = SP.donor_id
+       left join Info I_D on I_D.id = D.id and I_D.id_type  = 'Donor'
+       left join Info I_VC on I_VC.id = A.id and I_VC.id_type = 'VariantCall'
+       left join Info I_SR on I_SR.id = A.id and I_SR.id_type = 'SequencingRead';
+
+
 ---------------------------------------------------------------
 --            Drop Indices
 ---------------------------------------------------------------

--- a/song-server/src/main/resources/schema.sql
+++ b/song-server/src/main/resources/schema.sql
@@ -250,7 +250,7 @@ SELECT
        I_D.info as donor_info,
        I_SR.info as sequencingread_info,
        I_VC.info as variantcall_info
-from Analysis A
+FROM Analysis A
        left join Info I_A on I_A.id = A.id and I_A.id_type = 'Analysis'
        left join File F on F.analysis_id = A.id
        left join Info I_F on I_F.id = F.id and I_F.id_type = 'File'

--- a/song-server/src/test/java/bio/overture/song/server/service/AnalysisServiceTest.java
+++ b/song-server/src/test/java/bio/overture/song/server/service/AnalysisServiceTest.java
@@ -883,12 +883,12 @@ public class AnalysisServiceTest {
     assertFunctionEqual(l, r, AbstractAnalysis::getStudy);
     assertFunctionEqual(l, r, AbstractAnalysis::getInfoAsString);
 
-    val leftFiles = Sets.newHashSet(l.getFile());
-    val rightFiles = Sets.newHashSet(r.getFile());
+    val leftFiles = newHashSet(l.getFile());
+    val rightFiles = newHashSet(r.getFile());
     assertSetsMatch(leftFiles, rightFiles);
 
-    val leftSamples = Sets.newHashSet(l.getSample());
-    val rightSamples = Sets.newHashSet(r.getSample());
+    val leftSamples = newHashSet(l.getSample());
+    val rightSamples = newHashSet(r.getSample());
     assertSetsMatch(leftSamples, rightSamples);
 
     assertThat(l.getInfo()).isEqualTo(r.getInfo());
@@ -898,10 +898,6 @@ public class AnalysisServiceTest {
       assertThat(((VariantCallAnalysis)l).getExperiment()).isEqualTo(((VariantCallAnalysis)r).getExperiment());
     }
 
-  }
-
-  private static <T,R> int diff (T l, T r, Function<T, R> trFunction){
-    return  trFunction.apply(l).equals(trFunction.apply(r)) ? 0 : 1;
   }
 
 }

--- a/song-server/src/test/java/bio/overture/song/server/service/AnalysisServiceTest.java
+++ b/song-server/src/test/java/bio/overture/song/server/service/AnalysisServiceTest.java
@@ -872,13 +872,16 @@ public class AnalysisServiceTest {
     assertSongError(() -> service.readSamples(analysisId), ANALYSIS_MISSING_SAMPLES);
   }
 
+  private static <T,R> void assertFunctionEqual(T l, T r, Function<T,R> trFunction){
+    assertThat(trFunction.apply(l)).isEqualTo(trFunction.apply(r));
+  }
+
   private static void diff(AbstractAnalysis l, AbstractAnalysis r){
-    int count = diff(l, r, AbstractAnalysis::getAnalysisId);
-    count += diff(l, r, AbstractAnalysis::getAnalysisState);
-    count += diff(l, r, AbstractAnalysis::getAnalysisType);
-    count += diff(l, r, AbstractAnalysis::getStudy);
-    count += diff(l, r, AbstractAnalysis::getInfoAsString);
-    assertThat(count).isZero();
+    assertFunctionEqual(l, r, AbstractAnalysis::getAnalysisId);
+    assertFunctionEqual(l, r, AbstractAnalysis::getAnalysisState);
+    assertFunctionEqual(l, r, AbstractAnalysis::getAnalysisType);
+    assertFunctionEqual(l, r, AbstractAnalysis::getStudy);
+    assertFunctionEqual(l, r, AbstractAnalysis::getInfoAsString);
 
     val leftFiles = Sets.newHashSet(l.getFile());
     val rightFiles = Sets.newHashSet(r.getFile());
@@ -887,6 +890,14 @@ public class AnalysisServiceTest {
     val leftSamples = Sets.newHashSet(l.getSample());
     val rightSamples = Sets.newHashSet(r.getSample());
     assertSetsMatch(leftSamples, rightSamples);
+
+    assertThat(l.getInfo()).isEqualTo(r.getInfo());
+    if (l instanceof SequencingReadAnalysis && r instanceof SequencingReadAnalysis){
+      assertThat(((SequencingReadAnalysis)l).getExperiment()).isEqualTo(((SequencingReadAnalysis)r).getExperiment());
+    } else if (l instanceof VariantCallAnalysis && r instanceof VariantCallAnalysis){
+      assertThat(((VariantCallAnalysis)l).getExperiment()).isEqualTo(((VariantCallAnalysis)r).getExperiment());
+    }
+
   }
 
   private static <T,R> int diff (T l, T r, Function<T, R> trFunction){

--- a/song-server/src/test/java/bio/overture/song/server/service/AnalysisServiceTest.java
+++ b/song-server/src/test/java/bio/overture/song/server/service/AnalysisServiceTest.java
@@ -17,7 +17,6 @@
 package bio.overture.song.server.service;
 
 import bio.overture.song.core.model.enums.AnalysisStates;
-import bio.overture.song.core.testing.SongErrorAssertions;
 import bio.overture.song.core.utils.JsonUtils;
 import bio.overture.song.core.utils.RandomGenerator;
 import bio.overture.song.server.model.Metadata;
@@ -43,7 +42,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,13 +54,15 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Set;
-import java.util.stream.IntStream;
+import java.util.function.Function;
 
 import static com.google.common.collect.Sets.newHashSet;
 import static java.lang.String.format;
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
+import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.icgc.dcc.common.core.util.stream.Collectors.toImmutableSet;
@@ -82,6 +82,8 @@ import static bio.overture.song.core.testing.SongErrorAssertions.assertSongError
 import static bio.overture.song.core.utils.JsonUtils.fromJson;
 import static bio.overture.song.core.utils.JsonUtils.toJson;
 import static bio.overture.song.core.utils.RandomGenerator.createRandomGenerator;
+import static bio.overture.song.server.model.enums.AnalysisTypes.SEQUENCING_READ;
+import static bio.overture.song.server.model.enums.AnalysisTypes.VARIANT_CALL;
 import static bio.overture.song.server.repository.search.IdSearchRequest.createIdSearchRequest;
 import static bio.overture.song.server.utils.AnalysisGenerator.createAnalysisGenerator;
 import static bio.overture.song.server.utils.PayloadGenerator.createPayloadGenerator;
@@ -126,7 +128,7 @@ public class AnalysisServiceTest {
   @Autowired
   private SampleSetRepository sampleSetRepository;
 
-  private final RandomGenerator randomGenerator = createRandomGenerator(AnalysisServiceTest.class.getSimpleName());
+  private final RandomGenerator randomGenerator = createRandomGenerator(AnalysisServiceTest.class.getSimpleName(), 1539118165994L);//createRandomGenerator(AnalysisServiceTest.class.getSimpleName());
 
   private PayloadGenerator payloadGenerator;
   private AnalysisGenerator analysisGenerator;
@@ -159,7 +161,7 @@ public class AnalysisServiceTest {
     val a = service.securedDeepRead(DEFAULT_STUDY_ID, DEFAULT_ANALYSIS_ID);
     val expectedState = resolveAnalysisState(a.getAnalysisState());
     val actualState = service.readState(a.getAnalysisId());
-    Assertions.assertThat(actualState).isEqualTo(expectedState);
+    assertThat(actualState).isEqualTo(expectedState);
   }
 
   @Test
@@ -196,7 +198,7 @@ public class AnalysisServiceTest {
     analysis.setAnalysisId(randomAnalysisId);
     assertThat(service.isAnalysisExist(randomAnalysisId)).isFalse();
     val actualAnalysisId = service.create(DEFAULT_STUDY_ID, analysis, false);
-    Assertions.assertThat(actualAnalysisId).isEqualTo(randomAnalysisId);
+    assertThat(actualAnalysisId).isEqualTo(randomAnalysisId);
     assertThat(service.isAnalysisExist(randomAnalysisId)).isTrue();
   }
 
@@ -229,9 +231,8 @@ public class AnalysisServiceTest {
   @Test
   public void testReadAnalysisDNE() {
     val nonExistentAnalysisId = analysisGenerator.generateNonExistingAnalysisId();
-    SongErrorAssertions
-        .assertSongError(() -> service.securedDeepRead(DEFAULT_STUDY_ID, nonExistentAnalysisId), ANALYSIS_ID_NOT_FOUND);
-    SongErrorAssertions.assertSongError(() -> service.unsecuredDeepRead(nonExistentAnalysisId), ANALYSIS_ID_NOT_FOUND);
+    assertSongError(() -> service.securedDeepRead(DEFAULT_STUDY_ID, nonExistentAnalysisId), ANALYSIS_ID_NOT_FOUND);
+    assertSongError(() -> service.unsecuredDeepRead(nonExistentAnalysisId), ANALYSIS_ID_NOT_FOUND);
   }
 
   @Test
@@ -242,9 +243,8 @@ public class AnalysisServiceTest {
 
     variantCallRepository.deleteById(analysisId);
     assertThat(variantCallRepository.findById(analysisId)).isEmpty();
-    SongErrorAssertions
-        .assertSongError(() -> service.securedDeepRead(analysis.getStudy(), analysisId), VARIANT_CALL_NOT_FOUND);
-    SongErrorAssertions.assertSongError(() -> service.unsecuredDeepRead(analysisId), VARIANT_CALL_NOT_FOUND);
+    assertSongError(() -> service.securedDeepRead(analysis.getStudy(), analysisId), VARIANT_CALL_NOT_FOUND);
+    assertSongError(() -> service.unsecuredDeepRead(analysisId), VARIANT_CALL_NOT_FOUND);
   }
 
   @Test
@@ -255,9 +255,8 @@ public class AnalysisServiceTest {
 
     sequencingReadRepository.deleteById(analysisId);
     assertThat(sequencingReadRepository.findById(analysisId)).isEmpty();
-    SongErrorAssertions
-        .assertSongError(() -> service.securedDeepRead(analysis.getStudy(), analysisId), SEQUENCING_READ_NOT_FOUND);
-    SongErrorAssertions.assertSongError(() -> service.unsecuredDeepRead(analysisId), SEQUENCING_READ_NOT_FOUND);
+    assertSongError(() -> service.securedDeepRead(analysis.getStudy(), analysisId), SEQUENCING_READ_NOT_FOUND);
+    assertSongError(() -> service.unsecuredDeepRead(analysisId), SEQUENCING_READ_NOT_FOUND);
   }
 
   @Test
@@ -283,55 +282,55 @@ public class AnalysisServiceTest {
     assertInfoKVPair(experiment, "extraExperimentInfo","some more data for a variantCall experiment ex01");
 
     //Asserting Sample
-    Assertions.assertThat(a.getSample()).hasSize(2);
+    assertThat(a.getSample()).hasSize(2);
     val sample0 = a.getSample().get(0);
-    Assertions.assertThat(sample0.getSampleSubmitterId()).isEqualTo("internal_sample_98024759826836_fs01");
-    Assertions.assertThat(sample0.getSampleType()).isEqualTo("Total RNA");
+    assertThat(sample0.getSampleSubmitterId()).isEqualTo("internal_sample_98024759826836_fs01");
+    assertThat(sample0.getSampleType()).isEqualTo("Total RNA");
     assertInfoKVPair(sample0, "extraSampleInfo","some more data for a variantCall sample_fs01");
 
     val donor00 = sample0.getDonor();
-    Assertions.assertThat(donor00.getStudyId()).isEqualTo(DEFAULT_STUDY_ID);
-    Assertions.assertThat(donor00.getDonorGender()).isEqualTo("male");
-    Assertions.assertThat(donor00.getDonorSubmitterId()).isEqualTo("internal_donor_123456789-00_fs01");
+    assertThat(donor00.getStudyId()).isEqualTo(DEFAULT_STUDY_ID);
+    assertThat(donor00.getDonorGender()).isEqualTo("male");
+    assertThat(donor00.getDonorSubmitterId()).isEqualTo("internal_donor_123456789-00_fs01");
     assertInfoKVPair(donor00, "extraDonorInfo", "some more data for a variantCall donor_fs01");
 
     val specimen00 = sample0.getSpecimen();
-    Assertions.assertThat(specimen00.getDonorId()).isEqualTo(donor00.getDonorId());
-    Assertions.assertThat(specimen00.getSpecimenClass()).isEqualTo("Tumour");
-    Assertions.assertThat(specimen00.getSpecimenType()).isEqualTo("Primary tumour - other");
-    Assertions.assertThat(sample0.getSpecimenId()).isEqualTo(specimen00.getSpecimenId());
+    assertThat(specimen00.getDonorId()).isEqualTo(donor00.getDonorId());
+    assertThat(specimen00.getSpecimenClass()).isEqualTo("Tumour");
+    assertThat(specimen00.getSpecimenType()).isEqualTo("Primary tumour - other");
+    assertThat(sample0.getSpecimenId()).isEqualTo(specimen00.getSpecimenId());
     assertInfoKVPair(specimen00, "extraSpecimenInfo_0", "first for a variantCall specimen_fs01");
     assertInfoKVPair(specimen00, "extraSpecimenInfo_1", "second data for a variantCall specimen_fs01");
 
     val sample1 = a.getSample().get(1);
-    Assertions.assertThat(sample1.getSampleSubmitterId()).isEqualTo("internal_sample_98024759826836_fs02");
-    Assertions.assertThat(sample1.getSampleType()).isEqualTo("Total RNA");
+    assertThat(sample1.getSampleSubmitterId()).isEqualTo("internal_sample_98024759826836_fs02");
+    assertThat(sample1.getSampleType()).isEqualTo("Total RNA");
     assertInfoKVPair(sample1, "extraSampleInfo","some more data for a variantCall sample_fs02");
 
     val donor01 = sample1.getDonor();
-    Assertions.assertThat(donor01.getStudyId()).isEqualTo(DEFAULT_STUDY_ID);
-    Assertions.assertThat(donor01.getDonorGender()).isEqualTo("female");
-    Assertions.assertThat(donor01.getDonorSubmitterId()).isEqualTo("internal_donor_123456789-00_fs02");
+    assertThat(donor01.getStudyId()).isEqualTo(DEFAULT_STUDY_ID);
+    assertThat(donor01.getDonorGender()).isEqualTo("female");
+    assertThat(donor01.getDonorSubmitterId()).isEqualTo("internal_donor_123456789-00_fs02");
     assertInfoKVPair(donor01, "extraDonorInfo_0", "first data for a variantCall donor_fs02");
     assertInfoKVPair(donor01, "extraDonorInfo_1","second data for a variantCall donor_fs02");
 
     val specimen01 = sample1.getSpecimen();
-    Assertions.assertThat(specimen01.getDonorId()).isEqualTo(donor01.getDonorId());
-    Assertions.assertThat(specimen01.getSpecimenClass()).isEqualTo("Tumour");
-    Assertions.assertThat(specimen01.getSpecimenType()).isEqualTo("Primary tumour - other");
-    Assertions.assertThat(sample1.getSpecimenId()).isEqualTo(specimen01.getSpecimenId());
+    assertThat(specimen01.getDonorId()).isEqualTo(donor01.getDonorId());
+    assertThat(specimen01.getSpecimenClass()).isEqualTo("Tumour");
+    assertThat(specimen01.getSpecimenType()).isEqualTo("Primary tumour - other");
+    assertThat(sample1.getSpecimenId()).isEqualTo(specimen01.getSpecimenId());
     assertInfoKVPair(specimen01, "extraSpecimenInfo", "some more data for a variantCall specimen_fs02");
 
-    Assertions.assertThat(a.getFile()).hasSize(3);
+    assertThat(a.getFile()).hasSize(3);
     val file0 = a.getFile().get(0);
     val file1 = a.getFile().get(1);
     val file2 = a.getFile().get(2);
-    Assertions.assertThat(file0.getAnalysisId()).isEqualTo(analysisId);
-    Assertions.assertThat(file1.getAnalysisId()).isEqualTo(analysisId);
-    Assertions.assertThat(file2.getAnalysisId()).isEqualTo(analysisId);
-    Assertions.assertThat(file0.getStudyId()).isEqualTo(DEFAULT_STUDY_ID);
-    Assertions.assertThat(file1.getStudyId()).isEqualTo(DEFAULT_STUDY_ID);
-    Assertions.assertThat(file2.getStudyId()).isEqualTo(DEFAULT_STUDY_ID);
+    assertThat(file0.getAnalysisId()).isEqualTo(analysisId);
+    assertThat(file1.getAnalysisId()).isEqualTo(analysisId);
+    assertThat(file2.getAnalysisId()).isEqualTo(analysisId);
+    assertThat(file0.getStudyId()).isEqualTo(DEFAULT_STUDY_ID);
+    assertThat(file1.getStudyId()).isEqualTo(DEFAULT_STUDY_ID);
+    assertThat(file2.getStudyId()).isEqualTo(DEFAULT_STUDY_ID);
 
     val fileName0 = "a3bc0998a-3521-43fd-fa10-a834f3874e46-fn1.MUSE_1-0rc-vcf.20170711.somatic.snv_mnv.vcf.gz";
     val fileName1 ="a3bc0998a-3521-43fd-fa10-a834f3874e46-fn2.MUSE_1-0rc-vcf.20170711.somatic.snv_mnv.vcf.gz";
@@ -339,27 +338,27 @@ public class AnalysisServiceTest {
 
     for (val file : a.getFile()){
       if (file.getFileName().equals(fileName0)){
-        Assertions.assertThat(file.getFileName()).isEqualTo(fileName0);
-        Assertions.assertThat(file.getFileSize()).isEqualTo(376953);
-        Assertions.assertThat(file.getFileMd5sum()).isEqualTo("652b2e2b7133229a89650de27ad7fc41");
-        Assertions.assertThat(file.getFileAccess()).isEqualTo("controlled");
-        Assertions.assertThat(file.getFileType()).isEqualTo("VCF");
+        assertThat(file.getFileName()).isEqualTo(fileName0);
+        assertThat(file.getFileSize()).isEqualTo(376953);
+        assertThat(file.getFileMd5sum()).isEqualTo("652b2e2b7133229a89650de27ad7fc41");
+        assertThat(file.getFileAccess()).isEqualTo("controlled");
+        assertThat(file.getFileType()).isEqualTo("VCF");
         assertInfoKVPair(file, "extraFileInfo_0", "first data for variantCall file_fn1");
         assertInfoKVPair(file, "extraFileInfo_1", "second data for variantCall file_fn1");
       } else if (file.getFileName().equals(fileName1)){
-        Assertions.assertThat(file.getFileName()).isEqualTo(fileName1);
-        Assertions.assertThat(file.getFileSize()).isEqualTo(983820);
-        Assertions.assertThat(file.getFileMd5sum()).isEqualTo("b8b743a499e461922accad58fdbf25d2");
-        Assertions.assertThat(file.getFileAccess()).isEqualTo("open");
-        Assertions.assertThat(file.getFileType()).isEqualTo("VCF");
+        assertThat(file.getFileName()).isEqualTo(fileName1);
+        assertThat(file.getFileSize()).isEqualTo(983820);
+        assertThat(file.getFileMd5sum()).isEqualTo("b8b743a499e461922accad58fdbf25d2");
+        assertThat(file.getFileAccess()).isEqualTo("open");
+        assertThat(file.getFileType()).isEqualTo("VCF");
         assertInfoKVPair(file, "extraFileInfo", "some more data for variantCall file_fn2");
 
       } else if (file.getFileName().equals(fileName2)){
-        Assertions.assertThat(file.getFileName()).isEqualTo(fileName2);
-        Assertions.assertThat(file.getFileSize()).isEqualTo(4840);
-        Assertions.assertThat(file.getFileMd5sum()).isEqualTo("2b80298c2f312df7db482105053f889b");
-        Assertions.assertThat(file.getFileAccess()).isEqualTo("open");
-        Assertions.assertThat(file.getFileType()).isEqualTo("IDX");
+        assertThat(file.getFileName()).isEqualTo(fileName2);
+        assertThat(file.getFileSize()).isEqualTo(4840);
+        assertThat(file.getFileMd5sum()).isEqualTo("2b80298c2f312df7db482105053f889b");
+        assertThat(file.getFileAccess()).isEqualTo("open");
+        assertThat(file.getFileType()).isEqualTo("IDX");
         assertInfoKVPair(file, "extraFileInfo", "some more data for variantCall file_fn3");
       } else {
         fail(String.format("the fileName %s is not recognized", file.getFileName()));
@@ -397,57 +396,57 @@ public class AnalysisServiceTest {
 
 
     //Asserting Sample
-    Assertions.assertThat(a.getSample()).hasSize(2);
+    assertThat(a.getSample()).hasSize(2);
     val sample0 = a.getSample().get(0);
     sampleMap.put(sample0.getSampleId(), sample0);
-    Assertions.assertThat(sample0.getSampleSubmitterId()).isEqualTo("internal_sample_98024759826836_fr01");
-    Assertions.assertThat(sample0.getSampleType()).isEqualTo("Total RNA");
+    assertThat(sample0.getSampleSubmitterId()).isEqualTo("internal_sample_98024759826836_fr01");
+    assertThat(sample0.getSampleType()).isEqualTo("Total RNA");
     assertInfoKVPair(sample0, "extraSampleInfo","some more data for a sequencingRead sample_fr01");
 
     val donor00 = sample0.getDonor();
-    Assertions.assertThat(donor00.getStudyId()).isEqualTo(DEFAULT_STUDY_ID);
-    Assertions.assertThat(donor00.getDonorGender()).isEqualTo("male");
-    Assertions.assertThat(donor00.getDonorSubmitterId()).isEqualTo("internal_donor_123456789-00_fr01");
+    assertThat(donor00.getStudyId()).isEqualTo(DEFAULT_STUDY_ID);
+    assertThat(donor00.getDonorGender()).isEqualTo("male");
+    assertThat(donor00.getDonorSubmitterId()).isEqualTo("internal_donor_123456789-00_fr01");
     assertInfoKVPair(donor00, "extraDonorInfo", "some more data for a sequencingRead donor_fr01");
 
     val specimen00 = sample0.getSpecimen();
-    Assertions.assertThat(specimen00.getDonorId()).isEqualTo(donor00.getDonorId());
-    Assertions.assertThat(specimen00.getSpecimenClass()).isEqualTo("Tumour");
-    Assertions.assertThat(specimen00.getSpecimenType()).isEqualTo("Primary tumour - other");
-    Assertions.assertThat(sample0.getSpecimenId()).isEqualTo(specimen00.getSpecimenId());
+    assertThat(specimen00.getDonorId()).isEqualTo(donor00.getDonorId());
+    assertThat(specimen00.getSpecimenClass()).isEqualTo("Tumour");
+    assertThat(specimen00.getSpecimenType()).isEqualTo("Primary tumour - other");
+    assertThat(sample0.getSpecimenId()).isEqualTo(specimen00.getSpecimenId());
     assertInfoKVPair(specimen00, "extraSpecimenInfo_0", "first for a sequencingRead specimen_fr01");
     assertInfoKVPair(specimen00, "extraSpecimenInfo_1", "second data for a sequencingRead specimen_fr01");
 
     val sample1 = a.getSample().get(1);
     sampleMap.put(sample1.getSampleId(), sample1);
-    Assertions.assertThat(sample1.getSampleSubmitterId()).isEqualTo("internal_sample_98024759826836_fr02");
-    Assertions.assertThat(sample1.getSampleType()).isEqualTo("Total RNA");
+    assertThat(sample1.getSampleSubmitterId()).isEqualTo("internal_sample_98024759826836_fr02");
+    assertThat(sample1.getSampleType()).isEqualTo("Total RNA");
     assertInfoKVPair(sample1, "extraSampleInfo","some more data for a sequencingRead sample_fr02");
 
     val donor01 = sample1.getDonor();
-    Assertions.assertThat(donor01.getStudyId()).isEqualTo(DEFAULT_STUDY_ID);
-    Assertions.assertThat(donor01.getDonorGender()).isEqualTo("female");
-    Assertions.assertThat(donor01.getDonorSubmitterId()).isEqualTo("internal_donor_123456789-00_fr02");
+    assertThat(donor01.getStudyId()).isEqualTo(DEFAULT_STUDY_ID);
+    assertThat(donor01.getDonorGender()).isEqualTo("female");
+    assertThat(donor01.getDonorSubmitterId()).isEqualTo("internal_donor_123456789-00_fr02");
     assertInfoKVPair(donor01, "extraDonorInfo_0", "first data for a sequencingRead donor_fr02");
     assertInfoKVPair(donor01, "extraDonorInfo_1","second data for a sequencingRead donor_fr02");
 
     val specimen01 = sample1.getSpecimen();
-    Assertions.assertThat(specimen01.getDonorId()).isEqualTo(donor01.getDonorId());
-    Assertions.assertThat(specimen01.getSpecimenClass()).isEqualTo("Tumour");
-    Assertions.assertThat(specimen01.getSpecimenType()).isEqualTo("Primary tumour - other");
-    Assertions.assertThat(sample1.getSpecimenId()).isEqualTo(specimen01.getSpecimenId());
+    assertThat(specimen01.getDonorId()).isEqualTo(donor01.getDonorId());
+    assertThat(specimen01.getSpecimenClass()).isEqualTo("Tumour");
+    assertThat(specimen01.getSpecimenType()).isEqualTo("Primary tumour - other");
+    assertThat(sample1.getSpecimenId()).isEqualTo(specimen01.getSpecimenId());
     assertInfoKVPair(specimen01, "extraSpecimenInfo", "some more data for a sequencingRead specimen_fr02");
 
-    Assertions.assertThat(a.getFile()).hasSize(3);
+    assertThat(a.getFile()).hasSize(3);
     val file0 = a.getFile().get(0);
     val file1 = a.getFile().get(1);
     val file2 = a.getFile().get(2);
-    Assertions.assertThat(file0.getAnalysisId()).isEqualTo(analysisId);
-    Assertions.assertThat(file1.getAnalysisId()).isEqualTo(analysisId);
-    Assertions.assertThat(file2.getAnalysisId()).isEqualTo(analysisId);
-    Assertions.assertThat(file0.getStudyId()).isEqualTo(DEFAULT_STUDY_ID);
-    Assertions.assertThat(file1.getStudyId()).isEqualTo(DEFAULT_STUDY_ID);
-    Assertions.assertThat(file2.getStudyId()).isEqualTo(DEFAULT_STUDY_ID);
+    assertThat(file0.getAnalysisId()).isEqualTo(analysisId);
+    assertThat(file1.getAnalysisId()).isEqualTo(analysisId);
+    assertThat(file2.getAnalysisId()).isEqualTo(analysisId);
+    assertThat(file0.getStudyId()).isEqualTo(DEFAULT_STUDY_ID);
+    assertThat(file1.getStudyId()).isEqualTo(DEFAULT_STUDY_ID);
+    assertThat(file2.getStudyId()).isEqualTo(DEFAULT_STUDY_ID);
 
     val fileName0 = "a3bc0998a-3521-43fd-fa10-a834f3874e46-fn1.MUSE_1-0rc-vcf.20170711.bam";
     val fileName1 = "a3bc0998a-3521-43fd-fa10-a834f3874e46-fn2.MUSE_1-0rc-vcf.20170711.bam";
@@ -457,27 +456,27 @@ public class AnalysisServiceTest {
     for (val file : a.getFile()){
       fileMap.put(file.getFileName(), file);
       if (file.getFileName().equals(fileName0)){
-        Assertions.assertThat(file.getFileName()).isEqualTo(fileName0);
-        Assertions.assertThat(file.getFileSize()).isEqualTo(1212121);
-        Assertions.assertThat(file.getFileMd5sum()).isEqualTo("e2324667df8085eddfe95742047e153f");
-        Assertions.assertThat(file.getFileAccess()).isEqualTo("controlled");
-        Assertions.assertThat(file.getFileType()).isEqualTo("BAM");
+        assertThat(file.getFileName()).isEqualTo(fileName0);
+        assertThat(file.getFileSize()).isEqualTo(1212121);
+        assertThat(file.getFileMd5sum()).isEqualTo("e2324667df8085eddfe95742047e153f");
+        assertThat(file.getFileAccess()).isEqualTo("controlled");
+        assertThat(file.getFileType()).isEqualTo("BAM");
         assertInfoKVPair(file, "extraFileInfo_0", "first data for sequencingRead file_fn1");
         assertInfoKVPair(file, "extraFileInfo_1", "second data for sequencingRead file_fn1");
       } else if (file.getFileName().equals(fileName1)){
-        Assertions.assertThat(file.getFileName()).isEqualTo(fileName1);
-        Assertions.assertThat(file.getFileSize()).isEqualTo(34343);
-        Assertions.assertThat(file.getFileMd5sum()).isEqualTo("8b5379a29aac642d6fe1808826bd9e49");
-        Assertions.assertThat(file.getFileAccess()).isEqualTo("open");
-        Assertions.assertThat(file.getFileType()).isEqualTo("BAM");
+        assertThat(file.getFileName()).isEqualTo(fileName1);
+        assertThat(file.getFileSize()).isEqualTo(34343);
+        assertThat(file.getFileMd5sum()).isEqualTo("8b5379a29aac642d6fe1808826bd9e49");
+        assertThat(file.getFileAccess()).isEqualTo("open");
+        assertThat(file.getFileType()).isEqualTo("BAM");
         assertInfoKVPair(file, "extraFileInfo", "some more data for sequencingRead file_fn2");
 
       } else if (file.getFileName().equals(fileName2)){
-        Assertions.assertThat(file.getFileName()).isEqualTo(fileName2);
-        Assertions.assertThat(file.getFileSize()).isEqualTo(4840);
-        Assertions.assertThat(file.getFileMd5sum()).isEqualTo("61da923f32863a9c5fa3d2a0e19bdee3");
-        Assertions.assertThat(file.getFileAccess()).isEqualTo("open");
-        Assertions.assertThat(file.getFileType()).isEqualTo("BAI");
+        assertThat(file.getFileName()).isEqualTo(fileName2);
+        assertThat(file.getFileSize()).isEqualTo(4840);
+        assertThat(file.getFileMd5sum()).isEqualTo("61da923f32863a9c5fa3d2a0e19bdee3");
+        assertThat(file.getFileAccess()).isEqualTo("open");
+        assertThat(file.getFileType()).isEqualTo("BAI");
         assertInfoKVPair(file, "extraFileInfo", "some more data for sequencingRead file_fn3");
       } else {
         fail(String.format("the fileName %s is not recognized", file.getFileName()));
@@ -520,23 +519,23 @@ public class AnalysisServiceTest {
     expectedFiles.add(fileService.securedRead(DEFAULT_STUDY_ID, "FI1"));
     expectedFiles.add(fileService.securedRead(DEFAULT_STUDY_ID, "FI2"));
 
-    Assertions.assertThat(files).containsAll(expectedFiles);
+    assertThat(files).containsAll(expectedFiles);
     assertThat(expectedFiles).containsAll(files);
     val files2 = service.securedReadFiles(DEFAULT_STUDY_ID, DEFAULT_ANALYSIS_ID);
-    Assertions.assertThat(files2).containsOnlyElementsOf(files);
+    assertThat(files2).containsOnlyElementsOf(files);
   }
 
   @Test
   public void testReadFilesError() {
     val nonExistingAnalysisId = analysisGenerator.generateNonExistingAnalysisId();
-    SongErrorAssertions.assertSongError(() -> service.unsecuredReadFiles(nonExistingAnalysisId), ANALYSIS_ID_NOT_FOUND);
+    assertSongError(() -> service.unsecuredReadFiles(nonExistingAnalysisId), ANALYSIS_ID_NOT_FOUND);
 
   }
 
   @Test
   public void testDuplicateAnalysisAttemptError() {
     val an1 = service.securedDeepRead(DEFAULT_STUDY_ID,"AN1");
-    SongErrorAssertions.assertSongError(() -> service.create(an1.getStudy(), an1, true),
+    assertSongError(() -> service.create(an1.getStudy(), an1, true),
         DUPLICATE_ANALYSIS_ATTEMPT);
   }
 
@@ -552,7 +551,7 @@ public class AnalysisServiceTest {
         + ".json");
     analysisRaw.setAnalysisId(expectedAnalysisId);
     val actualAnalysisId = service.create(study, analysisRaw, false);
-    Assertions.assertThat(actualAnalysisId).isEqualTo(expectedAnalysisId);
+    assertThat(actualAnalysisId).isEqualTo(expectedAnalysisId);
     val analysis = service.securedDeepRead(study, actualAnalysisId);
     for (val file : analysis.getFile()){
       val filename = file.getFileName();
@@ -574,8 +573,7 @@ public class AnalysisServiceTest {
     payload.setAnalysisId(null);
 
     assertThat(payload.getAnalysisId()).isNull();
-    SongErrorAssertions
-        .assertSongError(() -> service.create(nonExistentStudyId, payload, false), STUDY_ID_DOES_NOT_EXIST);
+    assertSongError(() -> service.create(nonExistentStudyId, payload, false), STUDY_ID_DOES_NOT_EXIST);
   }
 
   @Test
@@ -612,20 +610,20 @@ public class AnalysisServiceTest {
         .filter(x -> AnalysisTypes.resolveAnalysisType(x.getAnalysisType()) == AnalysisTypes.SEQUENCING_READ)
         .collect(toSet());
     val actualVCAs = actualAnalyses.stream()
-        .filter(x -> AnalysisTypes.resolveAnalysisType(x.getAnalysisType()) == AnalysisTypes.VARIANT_CALL)
+        .filter(x -> AnalysisTypes.resolveAnalysisType(x.getAnalysisType()) == VARIANT_CALL)
         .collect(toSet());
 
-    Assertions.assertThat(actualSRAs).hasSize(sraMap.keySet().size());
-    Assertions.assertThat(actualVCAs).hasSize(vcaMap.keySet().size());
-    Assertions.assertThat(actualSRAs).containsAll(expectedSRAs);
-    Assertions.assertThat(actualVCAs).containsAll(expectedVCAs);
+    assertThat(actualSRAs).hasSize(sraMap.keySet().size());
+    assertThat(actualVCAs).hasSize(vcaMap.keySet().size());
+    assertThat(actualSRAs).containsAll(expectedSRAs);
+    assertThat(actualVCAs).containsAll(expectedVCAs);
 
     // Do a study-wide idSearch and verify the response effectively has the same
     // number of results as the getAnalysis method
     val searchedAnalyses = service.idSearch(studyId,
         createIdSearchRequest(null, null, null, null));
-    Assertions.assertThat(searchedAnalyses).hasSameSizeAs(expectedAnalyses);
-    Assertions.assertThat(searchedAnalyses).containsOnlyElementsOf(expectedAnalyses);
+    assertThat(searchedAnalyses).hasSameSizeAs(expectedAnalyses);
+    assertThat(searchedAnalyses).containsOnlyElementsOf(expectedAnalyses);
   }
 
   @Test
@@ -633,7 +631,7 @@ public class AnalysisServiceTest {
     val studyId = studyGenerator.createRandomStudy();
     val analysisGenerator = createAnalysisGenerator(studyId, service, randomGenerator);
     val numAnalysis = 10;
-    val expectedMap = IntStream.range(0, numAnalysis)
+    val expectedMap = range(0, numAnalysis)
         .boxed()
         .map(x -> {
           AbstractAnalysis a = analysisGenerator.createDefaultRandomSequencingReadAnalysis();
@@ -649,7 +647,7 @@ public class AnalysisServiceTest {
 
     assertThat(actualMap.keySet()).hasSize(1);
     assertThat(expectedMap).containsKey(PUBLISHED.toString());
-    Assertions.assertThat(actualMap).containsKey(PUBLISHED.toString());
+    assertThat(actualMap).containsKey(PUBLISHED.toString());
     assertThat(actualMap.get(PUBLISHED.toString())).hasSameSizeAs(expectedMap.get(PUBLISHED.toString()));
     assertThat(actualMap.get(PUBLISHED.toString())).containsExactlyElementsOf(expectedMap.get(PUBLISHED.toString()));
   }
@@ -670,16 +668,14 @@ public class AnalysisServiceTest {
   @Test
   public void testGetAnalysisDNEStudy() {
     val nonExistentStudyId = studyGenerator.generateNonExistingStudyId();
-    SongErrorAssertions
-        .assertSongError(() -> service.getAnalysis(nonExistentStudyId, PUBLISHED_ONLY), STUDY_ID_DOES_NOT_EXIST);
+    assertSongError(() -> service.getAnalysis(nonExistentStudyId, PUBLISHED_ONLY), STUDY_ID_DOES_NOT_EXIST);
   }
 
   @Test
   public void testIdSearchDNEStudy(){
     val nonExistentStudyId = studyGenerator.generateNonExistingStudyId();
     val idSearchRequest = createIdSearchRequest(null, null, null, null);
-    SongErrorAssertions
-        .assertSongError(() -> service.idSearch(nonExistentStudyId, idSearchRequest), STUDY_ID_DOES_NOT_EXIST);
+    assertSongError(() -> service.idSearch(nonExistentStudyId, idSearchRequest), STUDY_ID_DOES_NOT_EXIST);
   }
 
   @Test
@@ -689,17 +685,15 @@ public class AnalysisServiceTest {
 
     fileRepository.deleteAllByAnalysisId(analysisId1);
     assertThat(fileRepository.findAllByAnalysisId(analysisId1)).isEmpty();
-    SongErrorAssertions.assertSongError(() -> service.unsecuredReadFiles(analysisId1), ANALYSIS_MISSING_FILES);
-    SongErrorAssertions
-        .assertSongError(() -> service.securedReadFiles(analysis1.getStudy(), analysisId1), ANALYSIS_MISSING_FILES);
+    assertSongError(() -> service.unsecuredReadFiles(analysisId1), ANALYSIS_MISSING_FILES);
+    assertSongError(() -> service.securedReadFiles(analysis1.getStudy(), analysisId1), ANALYSIS_MISSING_FILES);
 
     val analysis2 = analysisGenerator.createDefaultRandomVariantCallAnalysis();
     val analysisId2 = analysis2.getAnalysisId();
     fileRepository.deleteAllByAnalysisId(analysisId2);
     assertThat(fileRepository.findAllByAnalysisId(analysisId2)).isEmpty();
-    SongErrorAssertions.assertSongError(() -> service.unsecuredReadFiles(analysisId2), ANALYSIS_MISSING_FILES);
-    SongErrorAssertions
-        .assertSongError(() -> service.securedReadFiles(analysis2.getStudy(), analysisId2), ANALYSIS_MISSING_FILES);
+    assertSongError(() -> service.unsecuredReadFiles(analysisId2), ANALYSIS_MISSING_FILES);
+    assertSongError(() -> service.securedReadFiles(analysis2.getStudy(), analysisId2), ANALYSIS_MISSING_FILES);
   }
 
   @Test
@@ -720,14 +714,12 @@ public class AnalysisServiceTest {
     assertSongError(() -> service.checkAnalysisAndStudyRelated(DEFAULT_STUDY_ID, nonExistentAnalysisId),
         ANALYSIS_ID_NOT_FOUND);
     assertSongError(() -> service.checkAnalysisExists(nonExistentAnalysisId), ANALYSIS_ID_NOT_FOUND);
-    SongErrorAssertions
-        .assertSongError(() -> service.securedDeepRead(DEFAULT_STUDY_ID ,nonExistentAnalysisId), ANALYSIS_ID_NOT_FOUND);
-    SongErrorAssertions.assertSongError(() -> service.unsecuredDeepRead(nonExistentAnalysisId), ANALYSIS_ID_NOT_FOUND);
-    SongErrorAssertions.assertSongError(() -> service.unsecuredReadFiles(nonExistentAnalysisId), ANALYSIS_ID_NOT_FOUND);
-    SongErrorAssertions
-        .assertSongError(() -> service.securedReadFiles(DEFAULT_STUDY_ID, nonExistentAnalysisId), ANALYSIS_ID_NOT_FOUND);
-    SongErrorAssertions.assertSongError(() -> service.readSamples(nonExistentAnalysisId), ANALYSIS_ID_NOT_FOUND);
-    SongErrorAssertions.assertSongError(() -> service.readState(nonExistentAnalysisId), ANALYSIS_ID_NOT_FOUND);
+    assertSongError(() -> service.securedDeepRead(DEFAULT_STUDY_ID ,nonExistentAnalysisId), ANALYSIS_ID_NOT_FOUND);
+    assertSongError(() -> service.unsecuredDeepRead(nonExistentAnalysisId), ANALYSIS_ID_NOT_FOUND);
+    assertSongError(() -> service.unsecuredReadFiles(nonExistentAnalysisId), ANALYSIS_ID_NOT_FOUND);
+    assertSongError(() -> service.securedReadFiles(DEFAULT_STUDY_ID, nonExistentAnalysisId), ANALYSIS_ID_NOT_FOUND);
+    assertSongError(() -> service.readSamples(nonExistentAnalysisId), ANALYSIS_ID_NOT_FOUND);
+    assertSongError(() -> service.readState(nonExistentAnalysisId), ANALYSIS_ID_NOT_FOUND);
   }
 
   @Test
@@ -744,7 +736,7 @@ public class AnalysisServiceTest {
   @Transactional
   public void testCheckAnalysisUnrelatedToStudy(){
     secureAnalysisTester.runSecureTest((s,a) -> service.checkAnalysisAndStudyRelated(s, a));
-    secureAnalysisTester.runSecureTest((s,a) -> service.securedDeepRead(s, a), AnalysisTypes.VARIANT_CALL);
+    secureAnalysisTester.runSecureTest((s,a) -> service.securedDeepRead(s, a), VARIANT_CALL);
     secureAnalysisTester.runSecureTest((s,a) -> service.securedDeepRead(s, a), AnalysisTypes.SEQUENCING_READ);
     secureAnalysisTester.runSecureTest((s,a) -> service.suppress(s, a));
     secureAnalysisTester.runSecureTest((s,a) -> service.securedReadFiles(s,a));
@@ -768,7 +760,7 @@ public class AnalysisServiceTest {
     val generator = createAnalysisGenerator(studyId, service, randomGenerator);
 
     val numCopies = 2;
-    val expectedAnalyses = IntStream.range(0, numCopies).boxed()
+    val expectedAnalyses = range(0, numCopies).boxed()
         .flatMap(x -> stream(AnalysisStates.values()))
         .map(x -> createSRAnalysisWithState(generator, x))
         .collect(toImmutableSet());
@@ -797,12 +789,52 @@ public class AnalysisServiceTest {
     // 7 - PUBLISHED,UNPUBLISHED,SUPPRESSED
     assertGetAnalysesForStudy(expectedAnalyses, studyId, UNPUBLISHED, SUPPRESSED, PUBLISHED);
 
-    SongErrorAssertions
-        .assertSongError(() -> service.getAnalysis(studyId, newHashSet(PUBLISHED.toString(), "SomethingElse")),
+    assertSongError(() -> service.getAnalysis(studyId, newHashSet(PUBLISHED.toString(), "SomethingElse")),
         MALFORMED_PARAMETER);
 
-    SongErrorAssertions.assertSongError(() -> service.getAnalysis(studyId, newHashSet("SomethingElse")),
+    assertSongError(() -> service.getAnalysis(studyId, newHashSet("SomethingElse")),
         MALFORMED_PARAMETER);
+  }
+
+  private static AnalysisTypes selectAnalysisType(int select){
+    return select % 2 == 0 ? VARIANT_CALL : SEQUENCING_READ;
+  }
+
+  @Test
+  @Transactional
+  public void testGetAnalysisForStudyView(){
+    val numAnalysesPerStudy = 100;
+    val numStudies = 3;
+    val studyIds = range(0, numStudies).boxed().map(x -> studyGenerator.createRandomStudy()).collect(toImmutableSet());
+    val study2AnalysesMap = studyIds.stream()
+        .map(x -> createAnalysisGenerator(x, service, randomGenerator))
+        .map(x ->
+            range(0, numAnalysesPerStudy).boxed()
+                .map(a -> (AbstractAnalysis)x.createDefaultRandomAnalysis(selectAnalysisType(a))))
+        .flatMap(x -> x)
+        .collect(groupingBy(AbstractAnalysis::getStudy));
+
+    val studyId = study2AnalysesMap.keySet().stream().findFirst().get();
+    val expectedAnalyses = study2AnalysesMap.get(studyId);
+
+    val expectedAnalysisMap = expectedAnalyses.stream()
+        .collect(toMap(x -> ((AbstractAnalysis) x).getAnalysisId(), x -> x));
+
+    val expectedAnalysisIds = expectedAnalysisMap.keySet();
+
+    val analysisStates = ImmutableSet.of(UNPUBLISHED.toString());
+
+    val actualAnalyses1 = service.getAnalysis(studyId, analysisStates);
+    val actualAnalyses2 = service.getAnalysisByView(studyId, analysisStates);
+
+    val actualAnalysisIds1 = actualAnalyses1.stream().map(AbstractAnalysis::getAnalysisId).collect(toImmutableSet());
+    val actualAnalysisIds2 = actualAnalyses2.stream().map(AbstractAnalysis::getAnalysisId).collect(toImmutableSet());
+
+    assertSetsMatch(actualAnalysisIds1, expectedAnalysisIds);
+    assertSetsMatch(actualAnalysisIds2, expectedAnalysisIds);
+
+    actualAnalyses1.forEach(x -> diff(x, expectedAnalysisMap.get(x.getAnalysisId())) );
+    actualAnalyses2.forEach(x -> diff(x, expectedAnalysisMap.get(x.getAnalysisId())) );
   }
 
   private void assertGetAnalysesForStudy(Set<AbstractAnalysis> expectedAnalyses, String studyId, AnalysisStates ... states){
@@ -837,7 +869,28 @@ public class AnalysisServiceTest {
     analysis.getSample().stream()
         .map(Sample::getSampleId)
         .forEach(sampleRepository::deleteById);
-    SongErrorAssertions.assertSongError(() -> service.readSamples(analysisId), ANALYSIS_MISSING_SAMPLES);
+    assertSongError(() -> service.readSamples(analysisId), ANALYSIS_MISSING_SAMPLES);
+  }
+
+  private static void diff(AbstractAnalysis l, AbstractAnalysis r){
+    int count = diff(l, r, AbstractAnalysis::getAnalysisId);
+    count += diff(l, r, AbstractAnalysis::getAnalysisState);
+    count += diff(l, r, AbstractAnalysis::getAnalysisType);
+    count += diff(l, r, AbstractAnalysis::getStudy);
+    count += diff(l, r, AbstractAnalysis::getInfoAsString);
+    assertThat(count).isZero();
+
+    val leftFiles = Sets.newHashSet(l.getFile());
+    val rightFiles = Sets.newHashSet(r.getFile());
+    assertSetsMatch(leftFiles, rightFiles);
+
+    val leftSamples = Sets.newHashSet(l.getSample());
+    val rightSamples = Sets.newHashSet(r.getSample());
+    assertSetsMatch(leftSamples, rightSamples);
+  }
+
+  private static <T,R> int diff (T l, T r, Function<T, R> trFunction){
+    return  trFunction.apply(l).equals(trFunction.apply(r)) ? 0 : 1;
   }
 
 }

--- a/song-server/src/test/java/bio/overture/song/server/service/PublishAnalysisTest.java
+++ b/song-server/src/test/java/bio/overture/song/server/service/PublishAnalysisTest.java
@@ -67,7 +67,7 @@ import static bio.overture.song.server.service.PublishAnalysisTest.RangeType.ALL
 import static bio.overture.song.server.service.PublishAnalysisTest.RangeType.NONE;
 import static bio.overture.song.server.service.PublishAnalysisTest.RangeType.SOME;
 import static bio.overture.song.server.utils.AnalysisGenerator.createAnalysisGenerator;
-import static bio.overture.song.server.utils.TestConstants.DEFAULT_STUDY_ID;
+import static bio.overture.song.server.utils.StudyGenerator.createStudyGenerator;
 
 @Slf4j
 @SpringBootTest
@@ -107,16 +107,17 @@ public class PublishAnalysisTest {
    */
   @Before
   public void beforeTest(){
-    assertThat(studyService.isStudyExist(DEFAULT_STUDY_ID)).isTrue();
     this.randomGenerator = createRandomGenerator(PublishAnalysisTest.class.getSimpleName());
-    val analysisGenerator = createAnalysisGenerator(DEFAULT_STUDY_ID, service, randomGenerator);
+    val newStudyId = createStudyGenerator(studyService, randomGenerator).createRandomStudy();
+    assertThat(studyService.isStudyExist(newStudyId)).isTrue();
+    val analysisGenerator = createAnalysisGenerator(newStudyId, service, randomGenerator);
 
     this.testAnalysis = analysisGenerator.createDefaultRandomAnalysis(randomGenerator.randomEnum(AnalysisTypes.class));
     this.testAnalysisId = testAnalysis.getAnalysisId();
     this.testStudyId = testAnalysis.getStudy();
 
     // Delete any previous files
-    fileService.securedDelete(DEFAULT_STUDY_ID,
+    fileService.securedDelete(newStudyId,
         testAnalysis.getFile().stream()
             .map(FileEntity::getObjectId)
             .collect(toList()));

--- a/song-server/src/test/java/bio/overture/song/server/utils/AnalysisGenerator.java
+++ b/song-server/src/test/java/bio/overture/song/server/utils/AnalysisGenerator.java
@@ -31,6 +31,8 @@ import static java.lang.String.format;
 import static lombok.AccessLevel.PRIVATE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static bio.overture.song.core.utils.RandomGenerator.createRandomGenerator;
+import static bio.overture.song.server.model.enums.AnalysisTypes.SEQUENCING_READ;
+import static bio.overture.song.server.model.enums.AnalysisTypes.VARIANT_CALL;
 import static bio.overture.song.server.utils.PayloadGenerator.createPayloadGenerator;
 import static bio.overture.song.server.utils.PayloadGenerator.resolveDefaultPayloadFilename;
 
@@ -69,9 +71,9 @@ public class AnalysisGenerator {
   }
 
   public <T extends AbstractAnalysis> T createDefaultRandomAnalysis(AnalysisTypes analysisType){
-    if (analysisType == AnalysisTypes.SEQUENCING_READ){
+    if (analysisType == SEQUENCING_READ){
       return (T)createDefaultRandomAnalysis(SequencingReadAnalysis.class);
-    } else if (analysisType == AnalysisTypes.VARIANT_CALL){
+    } else if (analysisType == VARIANT_CALL){
       return (T)createDefaultRandomAnalysis(VariantCallAnalysis.class);
     } else {
       throw new IllegalStateException(format("the analysis type '%s' cannot be processed", analysisType.toString()));


### PR DESCRIPTION
related to #338 

- flattened all the neccessary fields in the analysis object graph into a single row in a view called FullView
- using the Stream api, filtered, modified and collected objects and constructed the expected analysis
- although a new view was added to the sql schema, this does not constitute a breaking change since the fix requires a single `create view` command on the existing database (increase in minor version only)