### PR TITLE
The pipeline claims to install JDK11, then complains it can't find it.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,6 @@ spec:
     }
     tools {
        maven 'MVN3'
-       jdk 'OpenJDK 11'
     }
     stages {
         stage('Prepare') {


### PR DESCRIPTION
Removing it from the tools section in hopes there's a default value that works better.