### PR TITLE
Song 557 gender filetype

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,8 @@ services:
       POSTGRES_DB: song
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
+    ports:
+      - "8432:5432"
     volumes:
       - "./docker/song-db-init:/docker-entrypoint-initdb.d"
   aws-cli:

--- a/song-server/src/main/java/bio/overture/song/server/config/SchemaConfig.java
+++ b/song-server/src/main/java/bio/overture/song/server/config/SchemaConfig.java
@@ -38,8 +38,8 @@ public class SchemaConfig {
   @NotNull private Boolean enforceLatest;
 
   @Bean
-  public String analysisPayloadBaseJson() throws IOException {
-    val schemaRelativePath = SCHEMA_ANALYSIS_PATH.resolve("analysisPayload.json").toString();
+  public String analysisBaseJson() throws IOException {
+    val schemaRelativePath = SCHEMA_ANALYSIS_PATH.resolve("analysisBase.json").toString();
     return getResourceContent(schemaRelativePath);
   }
 

--- a/song-server/src/main/java/bio/overture/song/server/model/enums/Constants.java
+++ b/song-server/src/main/java/bio/overture/song/server/model/enums/Constants.java
@@ -27,7 +27,7 @@ public class Constants {
   public static final String VARIANT_CALL_TYPE = "variantCall";
   public static final String EMPTY_STRING = "";
   public static final Collection<String> ANALYSIS_STATE = list(AnalysisStates.toStringArray());
-  public static final Collection<String> DONOR_GENDER = list("male", "female", "unspecified");
+  public static final Collection<String> DONOR_GENDER = list("Male", "Female", "Other");
   public static final Collection<String> LIBRARY_STRATEGY =
       list(
           "WGS",

--- a/song-server/src/main/java/bio/overture/song/server/service/AnalysisTypeService.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/AnalysisTypeService.java
@@ -78,16 +78,16 @@ public class AnalysisTypeService {
   private final Schema analysisTypeMetaSchema;
 
   private final AnalysisSchemaRepository analysisSchemaRepository;
-  private final String analysisPayloadBaseContent;
+  private final String analysisBaseContent;
 
   @Autowired
   public AnalysisTypeService(
       @NonNull Supplier<Schema> analysisTypeMetaSchemaSupplier,
-      @Qualifier("analysisPayloadBaseJson") @NonNull String analysisPayloadBaseContent,
+      @Qualifier("analysisBaseJson") @NonNull String analysisBaseContent,
       @NonNull AnalysisSchemaRepository analysisSchemaRepository) {
     this.analysisTypeMetaSchema = analysisTypeMetaSchemaSupplier.get();
     this.analysisSchemaRepository = analysisSchemaRepository;
-    this.analysisPayloadBaseContent = analysisPayloadBaseContent;
+    this.analysisBaseContent = analysisBaseContent;
   }
 
   public Schema getAnalysisTypeMetaSchema() {
@@ -211,7 +211,7 @@ public class AnalysisTypeService {
   }
 
   private JsonNode renderPayloadJsonSchema(JsonNode schema) throws IOException {
-    val rendered = (ObjectNode) readTree(analysisPayloadBaseContent);
+    val rendered = (ObjectNode) readTree(analysisBaseContent);
     val baseProperties = (ObjectNode) rendered.path(PROPERTIES);
     val schemaProperties = (ObjectNode) schema.path(PROPERTIES);
     if (schema.has(REQUIRED)) {

--- a/song-server/src/main/java/bio/overture/song/server/service/UploadService.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/UploadService.java
@@ -16,21 +16,6 @@
  */
 package bio.overture.song.server.service;
 
-import bio.overture.song.core.model.AnalysisTypeId;
-import bio.overture.song.core.model.SubmitResponse;
-import bio.overture.song.server.model.dto.Payload;
-import com.fasterxml.jackson.databind.JsonNode;
-import lombok.NonNull;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
-import lombok.val;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
-import javax.transaction.Transactional;
-import java.io.IOException;
-
-import static java.util.Objects.isNull;
 import static bio.overture.song.core.exceptions.ServerErrors.ANALYSIS_TYPE_INCORRECT_VERSION;
 import static bio.overture.song.core.exceptions.ServerErrors.MALFORMED_PARAMETER;
 import static bio.overture.song.core.exceptions.ServerErrors.PAYLOAD_PARSING;
@@ -45,6 +30,20 @@ import static bio.overture.song.core.utils.Responses.OK;
 import static bio.overture.song.server.model.enums.ModelAttributeNames.ANALYSIS_TYPE;
 import static bio.overture.song.server.model.enums.ModelAttributeNames.NAME;
 import static bio.overture.song.server.model.enums.ModelAttributeNames.STUDY;
+import static java.util.Objects.isNull;
+
+import bio.overture.song.core.model.AnalysisTypeId;
+import bio.overture.song.core.model.SubmitResponse;
+import bio.overture.song.server.model.dto.Payload;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import javax.transaction.Transactional;
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
@@ -106,10 +105,18 @@ public class UploadService {
     checkServer(isNull(errors), getClass(), ANALYSIS_TYPE_INCORRECT_VERSION, errors);
   }
 
-  private AnalysisTypeId parseAnalysisTypeId(@NonNull JsonNode payloadJson){
-    checkServer(payloadJson.has(ANALYSIS_TYPE), getClass(), MALFORMED_PARAMETER, "The analysisType field cannot be null");
+  private AnalysisTypeId parseAnalysisTypeId(@NonNull JsonNode payloadJson) {
+    checkServer(
+        payloadJson.has(ANALYSIS_TYPE),
+        getClass(),
+        MALFORMED_PARAMETER,
+        "The analysisType field cannot be null");
     val analysisTypePath = payloadJson.path(ANALYSIS_TYPE);
-    checkServer(analysisTypePath.has(NAME), getClass(), MALFORMED_PARAMETER, "The analysisType name field cannot be null");
+    checkServer(
+        analysisTypePath.has(NAME),
+        getClass(),
+        MALFORMED_PARAMETER,
+        "The analysisType name field cannot be null");
     return fromJson(analysisTypePath, AnalysisTypeId.class);
   }
 

--- a/song-server/src/main/resources/data.sql
+++ b/song-server/src/main/resources/data.sql
@@ -3,8 +3,8 @@ insert into Study (id, name,description,organization) values ('XYZ234','X2-CA','
 insert into Info(id, id_type, info) values ('ABC123',  'Study', '{"name":"study1"}' );
 insert into Info(id, id_type, info) values ('XYZ234',  'Study', '{"name":"study2"}' );
 
-insert into Donor (id, study_id, submitter_id, gender) values ('DO1','ABC123', 'Subject-X23Alpha7', 'male');
-insert into Donor (id, study_id, submitter_id, gender) values ('DO2','XYZ234', 'Zalgon26', 'unspecified');
+insert into Donor (id, study_id, submitter_id, gender) values ('DO1','ABC123', 'Subject-X23Alpha7', 'Male');
+insert into Donor (id, study_id, submitter_id, gender) values ('DO2','XYZ234', 'Zalgon26', 'Other');
 insert into Info(id, id_type, info) values ('DO1',  'Donor', '{"name":"donor1"}' );
 insert into Info(id, id_type, info) values ('DO2',  'Donor', '{"name":"donor2"}' );
 

--- a/song-server/src/main/resources/db/migration/V1_4__file_enum_update.sql
+++ b/song-server/src/main/resources/db/migration/V1_4__file_enum_update.sql
@@ -1,0 +1,18 @@
+ALTER TYPE file_type RENAME TO _file_type;
+CREATE TYPE file_type as ENUM('FASTA','FAI','FASTQ','BAM','BAI','VCF','TBI','IDX','XML','TGZ','CRAM','CRAI');
+ALTER TABLE file RENAME COLUMN type TO _type;
+ALTER TABLE file ADD COLUMN type file_type;
+
+UPDATE file SET type='FASTA' where _type='FASTA';
+UPDATE file SET type='FAI'   where _type='FAI';
+UPDATE file SET type='FASTQ' where _type='FASTQ';
+UPDATE file SET type='BAM'   where _type='BAM';
+UPDATE file SET type='BAI'   where _type='BAI';
+UPDATE file SET type='VCF'   where _type='VCF';
+UPDATE file SET type='TBI'   where _type='TBI';
+UPDATE file SET type='IDX'   where _type='IDX';
+UPDATE file SET type='XML'   where _type='XML';
+UPDATE file SET type='TGZ'   where _type='TGZ';
+
+ALTER TABLE file DROP COLUMN _type;
+DROP TYPE _file_type CASCADE;

--- a/song-server/src/main/resources/db/migration/V1_5__donor_enum_update.sql
+++ b/song-server/src/main/resources/db/migration/V1_5__donor_enum_update.sql
@@ -1,0 +1,9 @@
+ALTER TYPE gender RENAME TO gender_old_type;
+CREATE TYPE gender as ENUM('Male','Female','Other');
+ALTER TABLE donor RENAME COLUMN gender TO gender_old;
+ALTER TABLE donor ADD COLUMN gender gender;
+UPDATE donor SET gender='Male' where gender_old='male';
+UPDATE donor SET gender='Female' where gender_old='female';
+UPDATE donor SET gender='Other' where gender_old='unspecified';
+ALTER TABLE donor DROP COLUMN gender_old;
+DROP TYPE gender_old_type CASCADE;

--- a/song-server/src/main/resources/schemas/analysis/analysisBase.json
+++ b/song-server/src/main/resources/schemas/analysis/analysisBase.json
@@ -28,7 +28,9 @@
 					"TBI",
 					"IDX",
 					"XML",
-					"TGZ"
+					"TGZ",
+					"CRAM",
+					"CRAI"
 				]
 			},
 			"fileData" :{
@@ -66,9 +68,9 @@
 			"donorGender": {
 				"type": "string",
 				"enum": [
-					"male",
-					"female",
-					"unspecified"
+					"Male",
+					"Female",
+					"Other"
 				]
 			},
 			"donorData": {

--- a/song-server/src/test/java/bio/overture/song/server/controller/EnforcedUploadControllerTest.java
+++ b/song-server/src/test/java/bio/overture/song/server/controller/EnforcedUploadControllerTest.java
@@ -17,6 +17,14 @@
 
 package bio.overture.song.server.controller;
 
+import static bio.overture.song.core.exceptions.ServerErrors.ANALYSIS_TYPE_INCORRECT_VERSION;
+import static bio.overture.song.core.exceptions.ServerErrors.MALFORMED_PARAMETER;
+import static bio.overture.song.core.exceptions.ServerErrors.SCHEMA_VIOLATION;
+import static bio.overture.song.core.utils.JsonUtils.objectToTree;
+import static bio.overture.song.core.utils.ResourceFetcher.ResourceType.TEST;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+
 import bio.overture.song.core.model.AnalysisTypeId;
 import bio.overture.song.core.utils.ResourceFetcher;
 import bio.overture.song.server.model.dto.UpdateAnalysisRequest;
@@ -35,16 +43,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.context.WebApplicationContext;
-
-import java.nio.file.Paths;
-
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static bio.overture.song.core.exceptions.ServerErrors.ANALYSIS_TYPE_INCORRECT_VERSION;
-import static bio.overture.song.core.exceptions.ServerErrors.MALFORMED_PARAMETER;
-import static bio.overture.song.core.exceptions.ServerErrors.SCHEMA_VIOLATION;
-import static bio.overture.song.core.utils.JsonUtils.objectToTree;
-import static bio.overture.song.core.utils.ResourceFetcher.ResourceType.TEST;
 
 @RunWith(SpringRunner.class)
 @AutoConfigureMockMvc(secure = false)
@@ -102,13 +100,17 @@ public class EnforcedUploadControllerTest extends AbstractEnforcedTester {
   public void testInvalidAnalysisType() {
 
     // Test invalid analysisType format
-    val j1 = (ObjectNode) DOCUMENTS_FETCHER.readJsonNode("validation/variantcall-malformed-analysisType1.json");
+    val j1 =
+        (ObjectNode)
+            DOCUMENTS_FETCHER.readJsonNode("validation/variantcall-malformed-analysisType1.json");
     getEndpointTester()
         .submitPostRequestAnd(getStudyId(), j1)
         .assertServerError(MALFORMED_PARAMETER);
 
     // Test invalid analysisType format
-    val j2 = (ObjectNode) DOCUMENTS_FETCHER.readJsonNode("validation/variantcall-malformed-analysisType2.json");
+    val j2 =
+        (ObjectNode)
+            DOCUMENTS_FETCHER.readJsonNode("validation/variantcall-malformed-analysisType2.json");
     getEndpointTester()
         .submitPostRequestAnd(getStudyId(), j2)
         .assertServerError(MALFORMED_PARAMETER);
@@ -121,15 +123,12 @@ public class EnforcedUploadControllerTest extends AbstractEnforcedTester {
     val s = (ObjectNode) j.get("sample").get(0);
     s.put("sampleType", "invalid");
 
-    getEndpointTester()
-      .submitPostRequestAnd(getStudyId(), j)
-      .assertServerError(SCHEMA_VIOLATION);
+    getEndpointTester().submitPostRequestAnd(getStudyId(), j).assertServerError(SCHEMA_VIOLATION);
 
     // Test invalid sample format
-    val j2 = (ObjectNode) DOCUMENTS_FETCHER.readJsonNode("validation/variantcall-malformed-sample.json");
-    getEndpointTester()
-        .submitPostRequestAnd(getStudyId(), j2)
-        .assertServerError(SCHEMA_VIOLATION);
+    val j2 =
+        (ObjectNode) DOCUMENTS_FETCHER.readJsonNode("validation/variantcall-malformed-sample.json");
+    getEndpointTester().submitPostRequestAnd(getStudyId(), j2).assertServerError(SCHEMA_VIOLATION);
   }
 
   @Test

--- a/song-server/src/test/java/bio/overture/song/server/service/AnalysisServiceTest.java
+++ b/song-server/src/test/java/bio/overture/song/server/service/AnalysisServiceTest.java
@@ -250,7 +250,7 @@ public class AnalysisServiceTest {
 
     val donor00 = sample0.getDonor();
     assertEquals(donor00.getStudyId(), DEFAULT_STUDY_ID);
-    assertEquals(donor00.getDonorGender(), "male");
+    assertEquals(donor00.getDonorGender(), "Male");
     assertEquals(donor00.getDonorSubmitterId(), "internal_donor_123456789-00_fs01");
     assertInfoKVPair(donor00, "extraDonorInfo", "some more data for a variantCall donor_fs01");
 
@@ -274,7 +274,7 @@ public class AnalysisServiceTest {
 
     val donor01 = sample1.getDonor();
     assertEquals(donor01.getStudyId(), DEFAULT_STUDY_ID);
-    assertEquals(donor01.getDonorGender(), "female");
+    assertEquals(donor01.getDonorGender(), "Female");
     assertEquals(donor01.getDonorSubmitterId(), "internal_donor_123456789-00_fs02");
     assertInfoKVPair(donor01, "extraDonorInfo_0", "first data for a variantCall donor_fs02");
     assertInfoKVPair(donor01, "extraDonorInfo_1", "second data for a variantCall donor_fs02");
@@ -383,7 +383,7 @@ public class AnalysisServiceTest {
 
     val donor00 = sample0.getDonor();
     assertEquals(donor00.getStudyId(), DEFAULT_STUDY_ID);
-    assertEquals(donor00.getDonorGender(), "male");
+    assertEquals(donor00.getDonorGender(), "Male");
     assertEquals(donor00.getDonorSubmitterId(), "internal_donor_123456789-00_fr01");
     assertInfoKVPair(donor00, "extraDonorInfo", "some more data for a sequencingRead donor_fr01");
 
@@ -407,7 +407,7 @@ public class AnalysisServiceTest {
 
     val donor01 = sample1.getDonor();
     assertEquals(donor01.getStudyId(), DEFAULT_STUDY_ID);
-    assertEquals(donor01.getDonorGender(), "female");
+    assertEquals(donor01.getDonorGender(), "Female");
     assertEquals(donor01.getDonorSubmitterId(), "internal_donor_123456789-00_fr02");
     assertInfoKVPair(donor01, "extraDonorInfo_0", "first data for a sequencingRead donor_fr02");
     assertInfoKVPair(donor01, "extraDonorInfo_1", "second data for a sequencingRead donor_fr02");

--- a/song-server/src/test/java/bio/overture/song/server/service/DonorServiceTest.java
+++ b/song-server/src/test/java/bio/overture/song/server/service/DonorServiceTest.java
@@ -84,7 +84,7 @@ public class DonorServiceTest {
     val d = service.readWithSpecimens(DEFAULT_DONOR_ID);
     assertNotNull(d);
     assertEquals(d.getDonorId(), DEFAULT_DONOR_ID);
-    assertEquals(d.getDonorGender(), "male");
+    assertEquals(d.getDonorGender(), "Male");
     assertEquals(d.getDonorSubmitterId(), "Subject-X23Alpha7");
     assertEquals(d.getSpecimens().size(), 2);
     assertEquals(getInfoName(d), "donor1");
@@ -115,7 +115,7 @@ public class DonorServiceTest {
     json.put("donorId", "");
     json.put("donorSubmitterId", "Subject X21-Alpha");
     json.put("studyId", studyId);
-    json.put("donorGender", "unspecified");
+    json.put("donorGender", "Other");
     json.put("species", "human");
 
     DonorWithSpecimens d = JsonUtils.mapper().convertValue(json, DonorWithSpecimens.class);
@@ -147,7 +147,7 @@ public class DonorServiceTest {
     d.setDonorId("");
     d.setDonorSubmitterId("Triangle-Arrow-S");
     d.setStudyId(studyId);
-    d.setDonorGender("male");
+    d.setDonorGender("Male");
     val id = service.create(d);
     assertEquals(id, d.getDonorId());
 
@@ -155,7 +155,7 @@ public class DonorServiceTest {
     d2.setDonorId(id);
     d2.setDonorSubmitterId("X21-Beta-17");
     d2.setStudyId(studyId);
-    d2.setDonorGender("female");
+    d2.setDonorGender("Female");
     d2.setInfo(info);
 
     val response = service.update(d2);
@@ -173,21 +173,21 @@ public class DonorServiceTest {
     d.setDonorId("");
     d.setDonorSubmitterId(donorSubmitterId);
     d.setStudyId(studyId);
-    d.setDonorGender("male");
+    d.setDonorGender("Male");
     val donorId = service.save(studyId, d);
     val initialDonor = service.securedRead(studyId, donorId);
-    assertEquals(initialDonor.getDonorGender(), "male");
+    assertEquals(initialDonor.getDonorGender(), "Male");
     assertTrue(service.isDonorExist(donorId));
 
     val dUpdate = new DonorWithSpecimens();
     dUpdate.setDonorSubmitterId(donorSubmitterId);
     dUpdate.setStudyId(studyId);
-    dUpdate.setDonorGender("female");
+    dUpdate.setDonorGender("Female");
     val donorId2 = service.save(studyId, dUpdate);
     assertTrue(service.isDonorExist(donorId2));
     assertEquals(donorId2, donorId);
     val updateDonor = service.securedRead(studyId, donorId2);
-    assertEquals(updateDonor.getDonorGender(), "female");
+    assertEquals(updateDonor.getDonorGender(), "Female");
   }
 
   @Test
@@ -200,7 +200,7 @@ public class DonorServiceTest {
     d.setDonorId("");
     d.setDonorSubmitterId(donorSubmitterId);
     d.setStudyId(studyId);
-    d.setDonorGender("male");
+    d.setDonorGender("Male");
     val donorId = service.create(d);
     assertTrue(service.isDonorExist(donorId));
     SongErrorAssertions.assertSongError(
@@ -210,7 +210,7 @@ public class DonorServiceTest {
     d2.setDonorId("");
     d2.setDonorSubmitterId(randomGenerator.generateRandomUUIDAsString());
     d2.setStudyId(randomStudyId);
-    d2.setDonorGender("female");
+    d2.setDonorGender("Female");
     SongErrorAssertions.assertSongError(
         () -> service.save(randomStudyId, d2), STUDY_ID_DOES_NOT_EXIST);
   }
@@ -224,7 +224,7 @@ public class DonorServiceTest {
     d1.setDonorId("");
     d1.setDonorSubmitterId(randomGenerator.generateRandomUUIDAsString());
     d1.setStudyId(randomStudyId);
-    d1.setDonorGender("female");
+    d1.setDonorGender("Female");
     val id1 = service.create(d1);
     d1.setDonorId(id1);
 
@@ -232,7 +232,7 @@ public class DonorServiceTest {
     d2.setDonorId("");
     d2.setDonorSubmitterId(randomGenerator.generateRandomUUIDAsString());
     d2.setStudyId(randomStudyId);
-    d2.setDonorGender("male");
+    d2.setDonorGender("Male");
     val id2 = service.create(d2);
     d2.setDonorId(id2);
 
@@ -293,7 +293,7 @@ public class DonorServiceTest {
     val donorIdSet = Sets.<String>newHashSet();
     for (int i = 0; i < numDonors; i++) {
       val d = new DonorWithSpecimens();
-      d.setDonorGender("male");
+      d.setDonorGender("Male");
       d.setStudyId(studyId);
       d.setDonorSubmitterId(randomGenerator.generateRandomUUIDAsString());
       val donorId = service.create(d);
@@ -377,7 +377,7 @@ public class DonorServiceTest {
         .donorId(randomDonorId)
         .donorSubmitterId(randomDonorSubmitterId)
         .studyId(randomStudyId)
-        .donorGender("male")
+        .donorGender("Male")
         .build();
   }
 }

--- a/song-server/src/test/java/bio/overture/song/server/service/SerializationTest.java
+++ b/song-server/src/test/java/bio/overture/song/server/service/SerializationTest.java
@@ -137,7 +137,7 @@ public class SerializationTest {
             .build();
 
     val d =
-        Donor.builder().donorGender("male").donorSubmitterId("internal_donor_123456789_01").build();
+        Donor.builder().donorGender("Male").donorSubmitterId("internal_donor_123456789_01").build();
     d.setInfo("ageCategory", "18-25");
     d.setInfo("riskCategory", "3b");
 

--- a/song-server/src/test/resources/documents/deserialization/sequencingRead-expected-serialization.json
+++ b/song-server/src/test/resources/documents/deserialization/sequencingRead-expected-serialization.json
@@ -23,7 +23,7 @@
         "donorId" : null,
         "donorSubmitterId" : "internal_donor_123456789_01",
         "studyId" : null,
-        "donorGender" : "male",
+        "donorGender" : "Male",
         "info" : {
           "ageCategory" : "18-25",
           "riskCategory" : "3b"

--- a/song-server/src/test/resources/documents/deserialization/sequencingRead-input-serialization.json
+++ b/song-server/src/test/resources/documents/deserialization/sequencingRead-input-serialization.json
@@ -26,7 +26,7 @@
     },
     "donor" : {
       "donorSubmitterId" : "internal_donor_123456789_01",
-      "donorGender" : "male",
+      "donorGender" : "Male",
       "ageCategory" : "18-25",
       "riskCategory" : "3b"
     }

--- a/song-server/src/test/resources/documents/deserialization/sequencingread-deserialize1.json
+++ b/song-server/src/test/resources/documents/deserialization/sequencingread-deserialize1.json
@@ -26,7 +26,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-00",
-        "donorGender": "female",
+        "donorGender": "Female",
         "ageCategory": "18-25",
         "riskCategory": "3b"
       }

--- a/song-server/src/test/resources/documents/deserialization/sequencingread-deserialize2.json
+++ b/song-server/src/test/resources/documents/deserialization/sequencingread-deserialize2.json
@@ -26,7 +26,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-00",
-        "donorGender": "female",
+        "donorGender": "Female",
         "ageCategory": "18-25",
         "riskCategory": "3b"
       }

--- a/song-server/src/test/resources/documents/deserialization/variantcall-deserialize1.json
+++ b/song-server/src/test/resources/documents/deserialization/variantcall-deserialize1.json
@@ -20,7 +20,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-00",
-        "donorGender": "female"
+        "donorGender": "Female"
       }
     }
   ],

--- a/song-server/src/test/resources/documents/deserialization/variantcall-deserialize2.json
+++ b/song-server/src/test/resources/documents/deserialization/variantcall-deserialize2.json
@@ -16,7 +16,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-00",
-        "donorGender": "female"
+        "donorGender": "Female"
       }
     }
   ],

--- a/song-server/src/test/resources/documents/export/variantcall-input1.json
+++ b/song-server/src/test/resources/documents/export/variantcall-input1.json
@@ -20,7 +20,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-00",
-        "donorGender": "female",
+        "donorGender": "Female",
         "age" : 34
       }
     }

--- a/song-server/src/test/resources/documents/export/variantcall-input2.json
+++ b/song-server/src/test/resources/documents/export/variantcall-input2.json
@@ -20,7 +20,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-02",
-        "donorGender": "female",
+        "donorGender": "Female",
         "age" : 342
       }
     }

--- a/song-server/src/test/resources/documents/export/variantcall-input3.json
+++ b/song-server/src/test/resources/documents/export/variantcall-input3.json
@@ -20,7 +20,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-03",
-        "donorGender": "male",
+        "donorGender": "Male",
         "age" : 343
       }
     }

--- a/song-server/src/test/resources/documents/export/variantcall-input4.json
+++ b/song-server/src/test/resources/documents/export/variantcall-input4.json
@@ -20,7 +20,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-04",
-        "donorGender": "male",
+        "donorGender": "Male",
         "age" : 344
       }
     }

--- a/song-server/src/test/resources/documents/export/variantcall-output1.json
+++ b/song-server/src/test/resources/documents/export/variantcall-output1.json
@@ -23,7 +23,7 @@
         }
       },
       "donor": {
-        "donorSubmitterId": "internal_donor_123456789-00", "donorGender": "female",
+        "donorSubmitterId": "internal_donor_123456789-00", "donorGender": "Female",
         "info": {
           "age" : 34
         }

--- a/song-server/src/test/resources/documents/export/variantcall-output2.json
+++ b/song-server/src/test/resources/documents/export/variantcall-output2.json
@@ -24,7 +24,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-02",
-        "donorGender": "female",
+        "donorGender": "Female",
         "info": {
           "age" : 342
         }

--- a/song-server/src/test/resources/documents/export/variantcall-output3.json
+++ b/song-server/src/test/resources/documents/export/variantcall-output3.json
@@ -24,7 +24,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-03",
-        "donorGender": "male",
+        "donorGender": "Male",
         "info": {
           "age" : 343
         }

--- a/song-server/src/test/resources/documents/export/variantcall-output4.json
+++ b/song-server/src/test/resources/documents/export/variantcall-output4.json
@@ -24,7 +24,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-04",
-        "donorGender": "male",
+        "donorGender": "Male",
         "info": {
           "age" : 344
         }

--- a/song-server/src/test/resources/documents/sequencingread-custom-analysis-id.json
+++ b/song-server/src/test/resources/documents/sequencingread-custom-analysis-id.json
@@ -28,7 +28,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-00",
-        "donorGender": "female",
+        "donorGender": "Female",
         "ageCategory": "18-25",
         "riskCategory": "3b"
       }

--- a/song-server/src/test/resources/documents/sequencingread-missing-required.json
+++ b/song-server/src/test/resources/documents/sequencingread-missing-required.json
@@ -27,7 +27,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-00",
-        "donorGender": "female",
+        "donorGender": "Female",
         "ageCategory": "18-25"
       }
     }

--- a/song-server/src/test/resources/documents/sequencingread-read-test.json
+++ b/song-server/src/test/resources/documents/sequencingread-read-test.json
@@ -27,7 +27,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-00_fr01",
-        "donorGender": "male",
+        "donorGender": "Male",
         "extraDonorInfo": "some more data for a sequencingRead donor_fr01"
       }
     },

--- a/song-server/src/test/resources/documents/sequencingread-read-test.json
+++ b/song-server/src/test/resources/documents/sequencingread-read-test.json
@@ -43,7 +43,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-00_fr02",
-        "donorGender": "female",
+        "donorGender": "Female",
         "extraDonorInfo_0": "first data for a sequencingRead donor_fr02",
         "extraDonorInfo_1": "second data for a sequencingRead donor_fr02"
       }

--- a/song-server/src/test/resources/documents/sequencingread-valid.json
+++ b/song-server/src/test/resources/documents/sequencingread-valid.json
@@ -27,7 +27,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-00",
-        "donorGender": "female",
+        "donorGender": "Female",
         "ageCategory": "18-25",
         "riskCategory": "3b"
       }

--- a/song-server/src/test/resources/documents/updateAnalysis/variantcall1-invalid-update-request-hasSampleField.json
+++ b/song-server/src/test/resources/documents/updateAnalysis/variantcall1-invalid-update-request-hasSampleField.json
@@ -18,7 +18,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-00",
-        "donorGender": "female"
+        "donorGender": "Female"
       }
     }
   ],

--- a/song-server/src/test/resources/documents/updateAnalysis/variantcall1-valid-payload.json
+++ b/song-server/src/test/resources/documents/updateAnalysis/variantcall1-valid-payload.json
@@ -20,7 +20,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-00",
-        "donorGender": "female"
+        "donorGender": "Female"
       }
     }
   ],

--- a/song-server/src/test/resources/documents/validation/dynamic-analysis-type/rendered-schema.json
+++ b/song-server/src/test/resources/documents/validation/dynamic-analysis-type/rendered-schema.json
@@ -28,7 +28,9 @@
           "TBI",
           "IDX",
           "XML",
-          "TGZ"
+          "TGZ",
+		  "CRAM",
+		  "CRAI"
         ]
       },
       "fileData" :{
@@ -66,9 +68,9 @@
       "donorGender": {
         "type": "string",
         "enum": [
-          "male",
-          "female",
-          "unspecified"
+          "Male",
+          "Female",
+          "Other"
         ]
       },
       "donorData": {

--- a/song-server/src/test/resources/documents/validation/sequencingRead.json
+++ b/song-server/src/test/resources/documents/validation/sequencingRead.json
@@ -26,7 +26,7 @@
     },
     "donor" : {
       "donorSubmitterId" : "internal_donor_123456789_01",
-      "donorGender" : "male",
+      "donorGender" : "Male",
       "ageCategory" : "18-25",
       "riskCategory" : "3b"
     }

--- a/song-server/src/test/resources/documents/validation/sequencingReadStudy.json
+++ b/song-server/src/test/resources/documents/validation/sequencingReadStudy.json
@@ -26,7 +26,7 @@
     },
     "donor" : {
       "donorSubmitterId" : "internal_donor_123456789_00",
-      "donorGender" : "male",
+      "donorGender" : "Male",
       "ageCategory" : "18-25",
       "riskCategory" : "3b"
     }

--- a/song-server/src/test/resources/documents/validation/sequencingReadWithArchive.json
+++ b/song-server/src/test/resources/documents/validation/sequencingReadWithArchive.json
@@ -27,7 +27,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789_01",
-        "donorGender": "male",
+        "donorGender": "Male",
         "ageCategory": "18-25",
         "riskCategory": "3b"
       }

--- a/song-server/src/test/resources/documents/validation/variantCall.json
+++ b/song-server/src/test/resources/documents/validation/variantCall.json
@@ -20,7 +20,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-00",
-        "donorGender": "female"
+        "donorGender": "Female"
       }
     }
   ],

--- a/song-server/src/test/resources/documents/validation/variantCallStudy.json
+++ b/song-server/src/test/resources/documents/validation/variantCallStudy.json
@@ -20,7 +20,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-00",
-        "donorGender": "female"
+        "donorGender": "Female"
       }
     }
   ],

--- a/song-server/src/test/resources/documents/validation/variantcall-malformed-analysisType1.json
+++ b/song-server/src/test/resources/documents/validation/variantcall-malformed-analysisType1.json
@@ -16,7 +16,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-00",
-        "donorGender": "female"
+        "donorGender": "Female"
       }
     }
   ],

--- a/song-server/src/test/resources/documents/validation/variantcall-malformed-analysisType2.json
+++ b/song-server/src/test/resources/documents/validation/variantcall-malformed-analysisType2.json
@@ -15,7 +15,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-00",
-        "donorGender": "female"
+        "donorGender": "Female"
       }
     }
   ],

--- a/song-server/src/test/resources/documents/validation/variantcall-malformed-sample.json
+++ b/song-server/src/test/resources/documents/validation/variantcall-malformed-sample.json
@@ -18,7 +18,7 @@
     },
     "donor": {
       "donorSubmitterId": "internal_donor_123456789-00",
-      "donorGender": "female"
+      "donorGender": "Female"
     }
   } ,
   "file": [

--- a/song-server/src/test/resources/documents/variantcall-missing-analysistype-name.json
+++ b/song-server/src/test/resources/documents/variantcall-missing-analysistype-name.json
@@ -19,7 +19,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-00",
-        "donorGender": "female"
+        "donorGender": "Female"
       }
     }
   ],

--- a/song-server/src/test/resources/documents/variantcall-missing-required.json
+++ b/song-server/src/test/resources/documents/variantcall-missing-required.json
@@ -16,7 +16,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-00",
-        "donorGender": "female"
+        "donorGender": "Female"
       }
     }
   ]

--- a/song-server/src/test/resources/documents/variantcall-read-test.json
+++ b/song-server/src/test/resources/documents/variantcall-read-test.json
@@ -39,7 +39,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-00_fs02",
-        "donorGender": "female",
+        "donorGender": "Female",
         "extraDonorInfo_0": "first data for a variantCall donor_fs02",
         "extraDonorInfo_1": "second data for a variantCall donor_fs02"
       }

--- a/song-server/src/test/resources/documents/variantcall-read-test.json
+++ b/song-server/src/test/resources/documents/variantcall-read-test.json
@@ -23,7 +23,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-00_fs01",
-        "donorGender": "male",
+        "donorGender": "Male",
         "extraDonorInfo": "some more data for a variantCall donor_fs01"
       }
     },

--- a/song-server/src/test/resources/documents/variantcall-valid-1.json
+++ b/song-server/src/test/resources/documents/variantcall-valid-1.json
@@ -21,7 +21,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-00-v0001",
-        "donorGender": "female"
+        "donorGender": "Female"
       }
     }
   ],

--- a/song-server/src/test/resources/documents/variantcall-valid.json
+++ b/song-server/src/test/resources/documents/variantcall-valid.json
@@ -20,7 +20,7 @@
       },
       "donor": {
         "donorSubmitterId": "internal_donor_123456789-00",
-        "donorGender": "female"
+        "donorGender": "Female"
       }
     }
   ],


### PR DESCRIPTION
Related to #557 

Regarding the migration scripts, the enums had to be migrated that way because using the `ALTER TYPE file_type ADD VALUE 'CRAM';` sql command is considered non-transactional. Flyway does not allow the mixing of non-transactional and transactional statements. The simplest and least hacky solution is the one in this pr, which essentially recreates the enum type.

