### PR TITLE
Added configurable token name for auth

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,8 +135,9 @@ services:
     environment:
       SERVER_PORT: 8080
       SPRING_PROFILES_ACTIVE: "prod,secure,default"
-      AUTH_SERVER_URL: http://ego-api:8080/o/check_token/
+      AUTH_SERVER_URL: http://ego-api:8080/o/check_api_key/
       AUTH_SERVER_CLIENTID: song
+      AUTH_SERVER_TOKENNAME: apiKey
       AUTH_SERVER_CLIENTSECRET: songsecret
       AUTH_SERVER_SCOPE_STUDY_PREFIX: song.
       AUTH_SERVER_SCOPE_STUDY_SUFFIX: .WRITE

--- a/song-server/src/main/java/bio/overture/song/server/config/SchemaConfig.java
+++ b/song-server/src/main/java/bio/overture/song/server/config/SchemaConfig.java
@@ -1,6 +1,15 @@
 package bio.overture.song.server.config;
 
+import static bio.overture.song.core.utils.JsonUtils.readTree;
+import static bio.overture.song.server.utils.JsonObjects.convertToJSONObject;
+import static bio.overture.song.server.utils.Resources.getResourceContent;
+
 import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.function.Supplier;
+import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.SneakyThrows;
@@ -14,16 +23,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
-import javax.validation.constraints.NotNull;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.function.Supplier;
-
-import static bio.overture.song.core.utils.JsonUtils.readTree;
-import static bio.overture.song.server.utils.JsonObjects.convertToJSONObject;
-import static bio.overture.song.server.utils.Resources.getResourceContent;
-
 @Getter
 @Setter
 @Validated
@@ -34,7 +33,8 @@ public class SchemaConfig {
 
   public static final Path SCHEMA_PATH = Paths.get("schemas");
   public static final Path SCHEMA_ANALYSIS_PATH = SCHEMA_PATH.resolve("analysis");
-  private static final Schema ANALYSIS_TYPE_REGISTRATION_SCHEMA = buildAnalysisTypeRegistrationSchema();
+  private static final Schema ANALYSIS_TYPE_REGISTRATION_SCHEMA =
+      buildAnalysisTypeRegistrationSchema();
   private static final Schema ANALYSIS_TYPE_ID_SCHEMA = buildAnalysisTypeIdSchema();
 
   @NotNull private Boolean enforceLatest;
@@ -72,7 +72,7 @@ public class SchemaConfig {
   }
 
   @SneakyThrows
-  private static Schema buildAnalysisTypeIdSchema(){
+  private static Schema buildAnalysisTypeIdSchema() {
     val filename = "analysisTypeId.json";
     val jsonSchema = convertToJSONObject(getSchemaAsJson(filename));
     return SchemaLoader.builder()
@@ -82,7 +82,6 @@ public class SchemaConfig {
         .build()
         .load()
         .build();
-
   }
 
   @SneakyThrows

--- a/song-server/src/main/java/bio/overture/song/server/config/TokenServiceConfig.java
+++ b/song-server/src/main/java/bio/overture/song/server/config/TokenServiceConfig.java
@@ -35,6 +35,7 @@ public class TokenServiceConfig {
   @Bean
   public RemoteTokenServices remoteTokenServices(
       @Value("${auth.server.url}") String checkTokenUrl,
+      @Value("${auth.server.tokenName:token}") String tokenName,
       @Value("${auth.server.clientId}") String clientId,
       @Value("${auth.server.clientSecret}") String clientSecret) {
     val remoteTokenServices = new RetryTokenServices();
@@ -42,7 +43,7 @@ public class TokenServiceConfig {
     remoteTokenServices.setClientId(clientId);
     remoteTokenServices.setClientSecret(clientSecret);
     remoteTokenServices.setAccessTokenConverter(accessTokenConverter());
-
+    remoteTokenServices.setTokenName(tokenName);
     return remoteTokenServices;
   }
 

--- a/song-server/src/main/java/bio/overture/song/server/controller/analysisType/AnalysisTypeController.java
+++ b/song-server/src/main/java/bio/overture/song/server/controller/analysisType/AnalysisTypeController.java
@@ -16,6 +16,18 @@
  */
 package bio.overture.song.server.controller.analysisType;
 
+import static bio.overture.song.core.utils.JsonUtils.readTree;
+import static bio.overture.song.core.utils.JsonUtils.toPrettyJson;
+import static bio.overture.song.server.controller.analysisType.AnalysisTypePageableResolver.DEFAULT_LIMIT;
+import static bio.overture.song.server.controller.analysisType.AnalysisTypePageableResolver.DEFAULT_OFFSET;
+import static bio.overture.song.server.model.enums.ModelAttributeNames.LIMIT;
+import static bio.overture.song.server.model.enums.ModelAttributeNames.OFFSET;
+import static bio.overture.song.server.model.enums.ModelAttributeNames.SORT;
+import static bio.overture.song.server.model.enums.ModelAttributeNames.SORTORDER;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import bio.overture.song.core.model.AnalysisType;
 import bio.overture.song.core.model.PageDTO;
 import bio.overture.song.server.model.dto.schema.RegisterAnalysisTypeRequest;
@@ -25,6 +37,8 @@ import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import java.util.List;
+import java.util.Set;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,21 +53,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
-import java.util.Set;
-
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-import static bio.overture.song.core.utils.JsonUtils.readTree;
-import static bio.overture.song.core.utils.JsonUtils.toPrettyJson;
-import static bio.overture.song.server.controller.analysisType.AnalysisTypePageableResolver.DEFAULT_LIMIT;
-import static bio.overture.song.server.controller.analysisType.AnalysisTypePageableResolver.DEFAULT_OFFSET;
-import static bio.overture.song.server.model.enums.ModelAttributeNames.LIMIT;
-import static bio.overture.song.server.model.enums.ModelAttributeNames.OFFSET;
-import static bio.overture.song.server.model.enums.ModelAttributeNames.SORT;
-import static bio.overture.song.server.model.enums.ModelAttributeNames.SORTORDER;
 
 @RestController
 @RequestMapping(path = "/schemas")
@@ -95,12 +94,13 @@ public class AnalysisTypeController {
   }
 
   @SneakyThrows
-  @GetMapping("/"+REGISTRATION)
+  @GetMapping("/" + REGISTRATION)
   @ApiOperation(
       value = "GetRegistrationSchema",
       notes = "Retrieves the meta-schema used to validate AnalysisType schemas during registration")
   public String getAnalysisTypeRegistrationSchema() {
-    return toPrettyJson(readTree(analysisTypeService.getAnalysisTypeRegistrationSchema().toString()));
+    return toPrettyJson(
+        readTree(analysisTypeService.getAnalysisTypeRegistrationSchema().toString()));
   }
 
   @PreAuthorize("@systemSecurity.authorize(authentication)")

--- a/song-server/src/main/java/bio/overture/song/server/model/entity/Sample.java
+++ b/song-server/src/main/java/bio/overture/song/server/model/entity/Sample.java
@@ -21,6 +21,10 @@ import bio.overture.song.core.model.Metadata;
 import bio.overture.song.server.model.enums.TableAttributeNames;
 import bio.overture.song.server.model.enums.TableNames;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -28,11 +32,6 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.ToString;
-
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
 
 @Entity
 @Table(name = TableNames.SAMPLE)

--- a/song-server/src/main/java/bio/overture/song/server/service/AnalysisTypeService.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/AnalysisTypeService.java
@@ -17,41 +17,6 @@
 
 package bio.overture.song.server.service;
 
-import bio.overture.song.core.model.AnalysisType;
-import bio.overture.song.core.model.AnalysisTypeId;
-import bio.overture.song.core.model.PageDTO;
-import bio.overture.song.server.controller.analysisType.AnalysisTypeController;
-import bio.overture.song.server.model.entity.AnalysisSchema;
-import bio.overture.song.server.repository.AnalysisSchemaRepository;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import lombok.NonNull;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
-import lombok.val;
-import org.everit.json.schema.Schema;
-import org.everit.json.schema.SchemaException;
-import org.everit.json.schema.ValidationException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
-import org.springframework.lang.Nullable;
-import org.springframework.stereotype.Service;
-
-import javax.transaction.Transactional;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.function.Supplier;
-import java.util.regex.Pattern;
-
-import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.collect.ImmutableList.toImmutableList;
-import static java.util.Objects.isNull;
-import static java.util.regex.Pattern.compile;
-import static org.apache.commons.lang.StringUtils.isBlank;
 import static bio.overture.song.core.exceptions.ServerErrors.ANALYSIS_TYPE_NOT_FOUND;
 import static bio.overture.song.core.exceptions.ServerErrors.ILLEGAL_ANALYSIS_TYPE_NAME;
 import static bio.overture.song.core.exceptions.ServerErrors.MALFORMED_JSON_SCHEMA;
@@ -68,6 +33,40 @@ import static bio.overture.song.server.utils.JsonSchemas.PROPERTIES;
 import static bio.overture.song.server.utils.JsonSchemas.REQUIRED;
 import static bio.overture.song.server.utils.JsonSchemas.buildSchema;
 import static bio.overture.song.server.utils.JsonSchemas.validateWithSchema;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.isNull;
+import static java.util.regex.Pattern.compile;
+import static org.apache.commons.lang.StringUtils.isBlank;
+
+import bio.overture.song.core.model.AnalysisType;
+import bio.overture.song.core.model.AnalysisTypeId;
+import bio.overture.song.core.model.PageDTO;
+import bio.overture.song.server.controller.analysisType.AnalysisTypeController;
+import bio.overture.song.server.model.entity.AnalysisSchema;
+import bio.overture.song.server.repository.AnalysisSchemaRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import javax.transaction.Transactional;
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.everit.json.schema.Schema;
+import org.everit.json.schema.SchemaException;
+import org.everit.json.schema.ValidationException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
@@ -291,8 +290,12 @@ public class AnalysisTypeService {
         "The analysisTypeId name '%s' does not match the regex: %s",
         analysisTypeName,
         ANALYSIS_TYPE_NAME_PATTERN.pattern());
-    checkServer(!analysisTypeName.equals(REGISTRATION), getClass(), ILLEGAL_ANALYSIS_TYPE_NAME,
-        "Cannot register an analysisType with name '%s'", REGISTRATION );
+    checkServer(
+        !analysisTypeName.equals(REGISTRATION),
+        getClass(),
+        ILLEGAL_ANALYSIS_TYPE_NAME,
+        "Cannot register an analysisType with name '%s'",
+        REGISTRATION);
   }
 
   private static void validatePositiveVersionsIfDefined(@Nullable Collection<Integer> versions) {

--- a/song-server/src/main/java/bio/overture/song/server/service/StorageService.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/StorageService.java
@@ -17,9 +17,22 @@
 
 package bio.overture.song.server.service;
 
+import static bio.overture.song.core.exceptions.ServerErrors.INVALID_STORAGE_DOWNLOAD_RESPONSE;
+import static bio.overture.song.core.exceptions.ServerErrors.STORAGE_OBJECT_NOT_FOUND;
+import static bio.overture.song.core.exceptions.ServerErrors.STORAGE_SERVICE_ERROR;
+import static bio.overture.song.core.exceptions.ServerException.buildServerException;
+import static bio.overture.song.core.exceptions.ServerException.checkServer;
+import static bio.overture.song.core.utils.Booleans.convertToBoolean;
+import static bio.overture.song.core.utils.JsonUtils.readTree;
+import static bio.overture.song.core.utils.Separators.SLASH;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpMethod.GET;
+
 import bio.overture.song.core.exceptions.BooleanConversionException;
 import bio.overture.song.server.model.StorageObject;
 import com.fasterxml.jackson.databind.JsonNode;
+import java.net.URL;
+import java.util.List;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -31,20 +44,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.web.client.RestTemplate;
-
-import java.net.URL;
-import java.util.List;
-
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.http.HttpMethod.GET;
-import static bio.overture.song.core.exceptions.ServerErrors.INVALID_STORAGE_DOWNLOAD_RESPONSE;
-import static bio.overture.song.core.exceptions.ServerErrors.STORAGE_OBJECT_NOT_FOUND;
-import static bio.overture.song.core.exceptions.ServerErrors.STORAGE_SERVICE_ERROR;
-import static bio.overture.song.core.exceptions.ServerException.buildServerException;
-import static bio.overture.song.core.exceptions.ServerException.checkServer;
-import static bio.overture.song.core.utils.Booleans.convertToBoolean;
-import static bio.overture.song.core.utils.JsonUtils.readTree;
-import static bio.overture.song.core.utils.Separators.SLASH;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/song-server/src/main/java/bio/overture/song/server/service/SubmitService.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/SubmitService.java
@@ -50,9 +50,9 @@ public class SubmitService {
 
   @Autowired
   public SubmitService(
-    @NonNull ValidationService validator,
-    @NonNull AnalysisService analysisService,
-    @NonNull StudyService studyService) {
+      @NonNull ValidationService validator,
+      @NonNull AnalysisService analysisService,
+      @NonNull StudyService studyService) {
     this.validator = validator;
     this.analysisService = analysisService;
     this.studyService = studyService;

--- a/song-server/src/main/java/bio/overture/song/server/service/ValidationService.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/ValidationService.java
@@ -16,28 +16,6 @@
  */
 package bio.overture.song.server.service;
 
-import bio.overture.song.core.model.AnalysisTypeId;
-import bio.overture.song.core.model.FileData;
-import bio.overture.song.server.model.enums.UploadStates;
-import bio.overture.song.server.repository.UploadRepository;
-import bio.overture.song.server.validation.SchemaValidator;
-import bio.overture.song.server.validation.ValidationResponse;
-import com.fasterxml.jackson.databind.JsonNode;
-import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
-import lombok.val;
-import org.everit.json.schema.Schema;
-import org.everit.json.schema.ValidationException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-
-import java.util.Optional;
-import java.util.function.Supplier;
-
-import static java.lang.String.format;
-import static java.util.Objects.isNull;
-import static org.apache.commons.lang.StringUtils.isBlank;
 import static bio.overture.song.core.exceptions.ServerErrors.MALFORMED_PARAMETER;
 import static bio.overture.song.core.exceptions.ServerException.checkServer;
 import static bio.overture.song.core.utils.JsonUtils.fromJson;
@@ -46,6 +24,27 @@ import static bio.overture.song.core.utils.Separators.COMMA;
 import static bio.overture.song.server.utils.JsonParser.extractAnalysisTypeFromPayload;
 import static bio.overture.song.server.utils.JsonSchemas.buildSchema;
 import static bio.overture.song.server.utils.JsonSchemas.validateWithSchema;
+import static java.lang.String.format;
+import static java.util.Objects.isNull;
+import static org.apache.commons.lang.StringUtils.isBlank;
+
+import bio.overture.song.core.model.AnalysisTypeId;
+import bio.overture.song.core.model.FileData;
+import bio.overture.song.server.model.enums.UploadStates;
+import bio.overture.song.server.repository.UploadRepository;
+import bio.overture.song.server.validation.SchemaValidator;
+import bio.overture.song.server.validation.ValidationResponse;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Optional;
+import java.util.function.Supplier;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.everit.json.schema.Schema;
+import org.everit.json.schema.ValidationException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
@@ -76,7 +75,7 @@ public class ValidationService {
 
   public Optional<String> validate(@NonNull JsonNode payload) {
     String errors = null;
-    try{
+    try {
       validateWithSchema(analysisTypeIdSchema, payload);
       val analysisTypeResult = extractAnalysisTypeFromPayload(payload);
       val analysisTypeId = fromJson(analysisTypeResult.get(), AnalysisTypeId.class);
@@ -88,7 +87,7 @@ public class ValidationService {
 
       val schema = buildSchema(analysisType.getSchema());
       validateWithSchema(schema, payload);
-    } catch (ValidationException e){
+    } catch (ValidationException e) {
       errors = COMMA.join(e.getAllMessages());
       log.error(errors);
     }

--- a/song-server/src/main/java/bio/overture/song/server/utils/JsonObjects.java
+++ b/song-server/src/main/java/bio/overture/song/server/utils/JsonObjects.java
@@ -1,18 +1,17 @@
 package bio.overture.song.server.utils;
 
+import static bio.overture.song.server.utils.Resources.getResourceContent;
+
 import bio.overture.song.core.utils.JsonUtils;
 import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.nio.file.Path;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.val;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONTokener;
-
-import java.io.IOException;
-import java.nio.file.Path;
-
-import static bio.overture.song.server.utils.Resources.getResourceContent;
 
 public class JsonObjects {
 
@@ -31,7 +30,7 @@ public class JsonObjects {
   }
 
   @SneakyThrows
-  public static JsonNode convertToJsonNode(@NonNull JSONObject j){
+  public static JsonNode convertToJsonNode(@NonNull JSONObject j) {
     return JsonUtils.readTree(j.toString());
   }
 }

--- a/song-server/src/main/resources/application.yml
+++ b/song-server/src/main/resources/application.yml
@@ -167,6 +167,7 @@ auth:
     url: "http://localhost:8084/check_token/"
     clientId: "3kJhz9pNtC0pFHAxr2SPkUkGjXrkWWqGcnPC0vBP"
     clientSecret: "v9mjRtuEVwpt7cgqnsq6mxtCa5FbUOpKLGh7WX8a1dWbBKfrM3iV3VYMtE60jr3W7GLWtNeYIaJ8EUxPkaInclWVXf64qKdR3IKwyfpDU7JhvWEwIYQYdwV1YAUZjB2e"
+    tokenName: "token"
     enableStrictSSL: false
     enableHttpLogging: false
     scope:

--- a/song-server/src/test/java/bio/overture/song/server/controller/AnalysisTypeControllerTest.java
+++ b/song-server/src/test/java/bio/overture/song/server/controller/AnalysisTypeControllerTest.java
@@ -17,56 +17,6 @@
 
 package bio.overture.song.server.controller;
 
-import bio.overture.song.core.exceptions.ServerError;
-import bio.overture.song.core.model.AnalysisType;
-import bio.overture.song.core.model.AnalysisTypeId;
-import bio.overture.song.core.utils.RandomGenerator;
-import bio.overture.song.core.utils.ResourceFetcher;
-import bio.overture.song.server.model.dto.schema.RegisterAnalysisTypeRequest;
-import bio.overture.song.server.repository.AnalysisSchemaRepository;
-import bio.overture.song.server.service.AnalysisTypeService;
-import bio.overture.song.server.utils.EndpointTester;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
-import lombok.val;
-import net.javacrumbs.jsonunit.core.Configuration;
-import org.everit.json.schema.Schema;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
-
-import javax.transaction.Transactional;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
-
-import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.collect.Sets.newHashSet;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.IntStream.range;
-import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
-import static net.javacrumbs.jsonunit.JsonAssert.when;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static bio.overture.song.core.exceptions.ServerErrors.ANALYSIS_TYPE_NOT_FOUND;
 import static bio.overture.song.core.exceptions.ServerErrors.ILLEGAL_ANALYSIS_TYPE_NAME;
 import static bio.overture.song.core.exceptions.ServerErrors.MALFORMED_JSON_SCHEMA;
@@ -83,6 +33,55 @@ import static bio.overture.song.core.utils.ResourceFetcher.ResourceType.MAIN;
 import static bio.overture.song.server.controller.analysisType.AnalysisTypeController.REGISTRATION;
 import static bio.overture.song.server.controller.analysisType.AnalysisTypePageableResolver.DEFAULT_LIMIT;
 import static bio.overture.song.server.utils.EndpointTester.createEndpointTester;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Sets.newHashSet;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.IntStream.range;
+import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
+import static net.javacrumbs.jsonunit.JsonAssert.when;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import bio.overture.song.core.exceptions.ServerError;
+import bio.overture.song.core.model.AnalysisType;
+import bio.overture.song.core.model.AnalysisTypeId;
+import bio.overture.song.core.utils.RandomGenerator;
+import bio.overture.song.core.utils.ResourceFetcher;
+import bio.overture.song.server.model.dto.schema.RegisterAnalysisTypeRequest;
+import bio.overture.song.server.repository.AnalysisSchemaRepository;
+import bio.overture.song.server.service.AnalysisTypeService;
+import bio.overture.song.server.utils.EndpointTester;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import javax.transaction.Transactional;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import net.javacrumbs.jsonunit.core.Configuration;
+import org.everit.json.schema.Schema;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
 @Slf4j
 @RunWith(SpringRunner.class)
@@ -374,7 +373,8 @@ public class AnalysisTypeControllerTest {
     val expected = readTree(analysisTypeRegistrationSchemaSupplier.get().toString());
 
     // Assert the actual retrieved resource matches the expected
-    val actual = endpointTester.getRegistrationSchemaGetRequestAnd().extractOneEntity(JsonNode.class);
+    val actual =
+        endpointTester.getRegistrationSchemaGetRequestAnd().extractOneEntity(JsonNode.class);
     assertJsonEquals(expected, actual, when(IGNORING_ARRAY_ORDER));
   }
 
@@ -606,8 +606,7 @@ public class AnalysisTypeControllerTest {
 
   @Test
   public void register_nameRegistration_illegalAnalysisTypeName() {
-    val inputValidSchema =
-        FETCHER.readJsonNode(Paths.get("schema-fixtures/valid.json").toString());
+    val inputValidSchema = FETCHER.readJsonNode(Paths.get("schema-fixtures/valid.json").toString());
 
     val name = REGISTRATION;
     val registerRequest =
@@ -620,7 +619,9 @@ public class AnalysisTypeControllerTest {
             .getResponse();
     val songError = parseErrorResponse(songErrorResponse);
     val actualMessage = songError.getMessage();
-    assertEquals(actualMessage, "[AnalysisTypeService::illegal.analysis.type.name] - Cannot register an analysisType with name 'registration'");
+    assertEquals(
+        actualMessage,
+        "[AnalysisTypeService::illegal.analysis.type.name] - Cannot register an analysisType with name 'registration'");
   }
 
   @Test

--- a/song-server/src/test/java/bio/overture/song/server/controller/EnforcedSubmitControllerTest.java
+++ b/song-server/src/test/java/bio/overture/song/server/controller/EnforcedSubmitControllerTest.java
@@ -17,12 +17,23 @@
 
 package bio.overture.song.server.controller;
 
+import static bio.overture.song.core.exceptions.ServerErrors.ANALYSIS_TYPE_INCORRECT_VERSION;
+import static bio.overture.song.core.exceptions.ServerErrors.MALFORMED_PARAMETER;
+import static bio.overture.song.core.exceptions.ServerErrors.SCHEMA_VIOLATION;
+import static bio.overture.song.core.exceptions.SongError.parseErrorResponse;
+import static bio.overture.song.core.utils.JsonUtils.objectToTree;
+import static bio.overture.song.core.utils.ResourceFetcher.ResourceType.TEST;
+import static java.util.Objects.isNull;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+
 import bio.overture.song.core.model.AnalysisTypeId;
 import bio.overture.song.core.utils.ResourceFetcher;
 import bio.overture.song.server.model.dto.UpdateAnalysisRequest;
 import bio.overture.song.server.service.AnalysisService;
 import bio.overture.song.server.service.StudyService;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.nio.file.Paths;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.val;
@@ -35,18 +46,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.context.WebApplicationContext;
-
-import java.nio.file.Paths;
-
-import static java.util.Objects.isNull;
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
-import static bio.overture.song.core.exceptions.ServerErrors.ANALYSIS_TYPE_INCORRECT_VERSION;
-import static bio.overture.song.core.exceptions.ServerErrors.MALFORMED_PARAMETER;
-import static bio.overture.song.core.exceptions.ServerErrors.SCHEMA_VIOLATION;
-import static bio.overture.song.core.exceptions.SongError.parseErrorResponse;
-import static bio.overture.song.core.utils.JsonUtils.objectToTree;
-import static bio.overture.song.core.utils.ResourceFetcher.ResourceType.TEST;
 
 @RunWith(SpringRunner.class)
 @AutoConfigureMockMvc(secure = false)

--- a/song-server/src/test/java/bio/overture/song/server/utils/EndpointTester.java
+++ b/song-server/src/test/java/bio/overture/song/server/utils/EndpointTester.java
@@ -17,12 +17,23 @@
 
 package bio.overture.song.server.utils;
 
+import static bio.overture.song.core.utils.Separators.SLASH;
+import static bio.overture.song.server.controller.analysisType.AnalysisTypeController.REGISTRATION;
+import static bio.overture.song.server.model.enums.ModelAttributeNames.LIMIT;
+import static bio.overture.song.server.model.enums.ModelAttributeNames.OFFSET;
+import static bio.overture.song.server.model.enums.ModelAttributeNames.SORT;
+import static bio.overture.song.server.model.enums.ModelAttributeNames.SORTORDER;
+import static bio.overture.song.server.utils.SongErrorResultMatcher.songErrorContent;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
 import bio.overture.song.core.exceptions.ServerError;
 import bio.overture.song.server.model.dto.schema.RegisterAnalysisTypeRequest;
 import bio.overture.song.server.utils.web.MockMvcWebResource;
 import bio.overture.song.server.utils.web.ResponseOption;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
+import java.util.Collection;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
@@ -31,18 +42,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.lang.Nullable;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.Collection;
-
-import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static bio.overture.song.core.utils.Separators.SLASH;
-import static bio.overture.song.server.controller.analysisType.AnalysisTypeController.REGISTRATION;
-import static bio.overture.song.server.model.enums.ModelAttributeNames.LIMIT;
-import static bio.overture.song.server.model.enums.ModelAttributeNames.OFFSET;
-import static bio.overture.song.server.model.enums.ModelAttributeNames.SORT;
-import static bio.overture.song.server.model.enums.ModelAttributeNames.SORTORDER;
-import static bio.overture.song.server.utils.SongErrorResultMatcher.songErrorContent;
 
 @RequiredArgsConstructor
 public class EndpointTester {

--- a/song-server/src/test/java/bio/overture/song/server/validation/SchemaValidationTests.java
+++ b/song-server/src/test/java/bio/overture/song/server/validation/SchemaValidationTests.java
@@ -16,12 +16,29 @@
  */
 package bio.overture.song.server.validation;
 
+import static bio.overture.song.core.utils.JsonUtils.readTree;
+import static bio.overture.song.core.utils.JsonUtils.toJson;
+import static bio.overture.song.core.utils.Separators.COMMA;
+import static bio.overture.song.server.utils.JsonObjects.convertToJSONObject;
+import static bio.overture.song.server.utils.JsonSchemas.buildSchema;
+import static bio.overture.song.server.utils.generator.LegacyAnalysisTypeName.SEQUENCING_READ;
+import static bio.overture.song.server.utils.generator.LegacyAnalysisTypeName.VARIANT_CALL;
+import static bio.overture.song.server.utils.generator.PayloadGenerator.createPayloadGenerator;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Streams.stream;
+import static java.lang.Thread.currentThread;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import bio.overture.song.core.model.AnalysisTypeId;
 import bio.overture.song.server.service.AnalysisTypeService;
 import bio.overture.song.server.utils.generator.LegacyAnalysisTypeName;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.Set;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -33,24 +50,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import java.io.InputStream;
-import java.util.Optional;
-import java.util.Set;
-
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.common.collect.Streams.stream;
-import static java.lang.Thread.currentThread;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static bio.overture.song.core.utils.JsonUtils.readTree;
-import static bio.overture.song.core.utils.JsonUtils.toJson;
-import static bio.overture.song.core.utils.Separators.COMMA;
-import static bio.overture.song.server.utils.JsonObjects.convertToJSONObject;
-import static bio.overture.song.server.utils.JsonSchemas.buildSchema;
-import static bio.overture.song.server.utils.generator.LegacyAnalysisTypeName.SEQUENCING_READ;
-import static bio.overture.song.server.utils.generator.LegacyAnalysisTypeName.VARIANT_CALL;
-import static bio.overture.song.server.utils.generator.PayloadGenerator.createPayloadGenerator;
 
 @Slf4j
 @SpringBootTest

--- a/song-server/src/test/java/bio/overture/song/server/validation/ValidationServiceTest.java
+++ b/song-server/src/test/java/bio/overture/song/server/validation/ValidationServiceTest.java
@@ -16,11 +16,21 @@
  */
 package bio.overture.song.server.validation;
 
+import static bio.overture.song.core.utils.RandomGenerator.createRandomGenerator;
+import static bio.overture.song.core.utils.Separators.COMMA;
+import static bio.overture.song.server.utils.TestFiles.getJsonNodeFromClasspath;
+import static com.google.common.collect.Lists.newArrayList;
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import bio.overture.song.core.utils.RandomGenerator;
 import bio.overture.song.server.service.ValidationService;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Maps;
+import java.util.Map;
 import lombok.val;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,17 +40,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
-
-import java.util.Map;
-
-import static com.google.common.collect.Lists.newArrayList;
-import static java.lang.String.format;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static bio.overture.song.core.utils.RandomGenerator.createRandomGenerator;
-import static bio.overture.song.core.utils.Separators.COMMA;
-import static bio.overture.song.server.utils.TestFiles.getJsonNodeFromClasspath;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)


### PR DESCRIPTION
ran the integration test using /o/check_api_key with tokenname==apiKey, with the following command:

`make clean test-score-upload DEMO_MODE=1`

Unfortunatly, this PR is mixed with autoformatted code. The files of interest are:
- docker-compose.yml
- TokenServiceConfig.java
- application.yml