### PR TITLE
Update song-client docker permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,17 +18,13 @@ ENV SONG_CLIENT_HOME   /song-client
 ENV CLIENT_DIST_DIR    /song-client-dist
 ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $PATH:$SONG_CLIENT_HOME/bin
-
 ENV SONG_HOME /home/song
 ENV SONG_USER song
-ENV SONG_UID 9999
-ENV SONG_GID 9999
 
-RUN addgroup -S -g $SONG_GID $SONG_USER  \
-    && adduser -S -u $SONG_UID -G $SONG_USER $SONG_USER  \
-    && mkdir -p $SONG_CLIENT_HOME $SONG_HOME \
-    && chown -R $SONG_UID:$SONG_GID $SONG_CLIENT_HOME $SONG_HOME \
-	&& apk add bash
+RUN adduser $SONG_USER >& /dev/null || true \
+	&& mkdir -p $SONG_CLIENT_HOME \
+	&& chown -R $SONG_USER:$SONG_USER $SONG_CLIENT_HOME \
+	&& apk add bash==5.0.11-r1
 
 COPY --from=builder /srv/song-client/target/song-client-*-dist.tar.gz /song-client.tar.gz
 
@@ -37,12 +33,10 @@ RUN tar zxvf song-client.tar.gz -C /tmp \
     && mv -f /tmp/song-client-*  /tmp/song-client-dist  \
     && cp -r /tmp/song-client-dist $CLIENT_DIST_DIR \
 	&& mkdir -p $CLIENT_DIST_DIR/logs \
-	&& touch $CLIENT_DIST_DIR/logs/client.log \
-	&& chmod 777 $CLIENT_DIST_DIR/logs/client.log \
 	&& mv $CLIENT_DIST_DIR/* $SONG_CLIENT_HOME \
-	&& chown -R $SONG_UID:$SONG_GID $SONG_CLIENT_HOME
+	&& chown -R $SONG_USER:$SONG_USER $SONG_CLIENT_HOME
 
-USER $SONG_UID
+USER $SONG_USER
 
 # Set working directory for convenience with interactive usage
 WORKDIR $SONG_CLIENT_HOME

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,14 +18,16 @@ ENV SONG_CLIENT_HOME   /song-client
 ENV CLIENT_DIST_DIR    /song-client-dist
 ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $PATH:$SONG_CLIENT_HOME/bin
+
+ENV SONG_HOME /home/song
 ENV SONG_USER song
 ENV SONG_UID 9999
 ENV SONG_GID 9999
 
 RUN addgroup -S -g $SONG_GID $SONG_USER  \
     && adduser -S -u $SONG_UID -G $SONG_USER $SONG_USER  \
-    && mkdir $SONG_CLIENT_HOME \
-    && chown -R $SONG_UID:$SONG_GID $SONG_CLIENT_HOME \
+    && mkdir -p $SONG_CLIENT_HOME $SONG_HOME \
+    && chown -R $SONG_UID:$SONG_GID $SONG_CLIENT_HOME $SONG_HOME \
 	&& apk add bash
 
 COPY --from=builder /srv/song-client/target/song-client-*-dist.tar.gz /song-client.tar.gz
@@ -38,8 +40,9 @@ RUN tar zxvf song-client.tar.gz -C /tmp \
 	&& touch $CLIENT_DIST_DIR/logs/client.log \
 	&& chmod 777 $CLIENT_DIST_DIR/logs/client.log \
 	&& mv $CLIENT_DIST_DIR/* $SONG_CLIENT_HOME \
-	&& chown -R $SONG_UID:$SONG_GID $SONG_CLIENT_HOME \
-	&& chmod -R 777 $SONG_CLIENT_HOME/logs
+	&& chown -R $SONG_UID:$SONG_GID $SONG_CLIENT_HOME
+
+USER $SONG_UID
 
 # Set working directory for convenience with interactive usage
 WORKDIR $SONG_CLIENT_HOME

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,14 +9,11 @@ ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $PATH:$SONG_CLIENT_HOME/bin
 ENV SONG_HOME /home/song
 ENV SONG_USER song
-ENV SONG_UID 9999
-ENV SONG_GID 9999
 
-RUN addgroup -S -g $SONG_GID $SONG_USER  \
-    && adduser -S -u $SONG_UID -G $SONG_USER $SONG_USER  \
-    && mkdir -p $SONG_CLIENT_HOME $SONG_HOME \
-    && chown -R $SONG_UID:$SONG_GID $SONG_CLIENT_HOME $SONG_HOME \
-	&& apk add bash
+RUN adduser $SONG_USER >& /dev/null || true \
+	&& mkdir -p $SONG_CLIENT_HOME \
+	&& chown -R $SONG_USER:$SONG_USER $SONG_CLIENT_HOME  \
+	&& apk add bash==5.0.11-r1
 
 COPY song-client/target/song-client-*-dist.tar.gz  /song-client.tar.gz
 
@@ -25,11 +22,11 @@ RUN tar zxvf song-client.tar.gz -C /tmp \
     && mv -f /tmp/song-client-*  /tmp/song-client-dist  \
     && cp -r /tmp/song-client-dist $CLIENT_DIST_DIR \
 	&& mkdir -p $CLIENT_DIST_DIR/logs \
-	&& touch $CLIENT_DIST_DIR/logs/client.log \
-	&& chmod 777 $CLIENT_DIST_DIR/logs/client.log \
+	&& touch $CLIENT_DIST_DIR/logs \
 	&& mv $CLIENT_DIST_DIR/* $SONG_CLIENT_HOME \
-	&& chown -R $SONG_UID:$SONG_GID $SONG_CLIENT_HOME
+	&& chown -R $SONG_USER:$SONG_USER $SONG_CLIENT_HOME
 
+USER $SONG_USER
 
 # Set working directory for convenience with interactive usage
 WORKDIR $SONG_CLIENT_HOME

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,14 +7,15 @@ ENV SONG_CLIENT_HOME   /song-client
 ENV CLIENT_DIST_DIR    /song-client-dist
 ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $PATH:$SONG_CLIENT_HOME/bin
+ENV SONG_HOME /home/song
 ENV SONG_USER song
 ENV SONG_UID 9999
 ENV SONG_GID 9999
 
 RUN addgroup -S -g $SONG_GID $SONG_USER  \
     && adduser -S -u $SONG_UID -G $SONG_USER $SONG_USER  \
-    && mkdir $SONG_CLIENT_HOME \
-    && chown -R $SONG_UID:$SONG_GID $SONG_CLIENT_HOME \
+    && mkdir -p $SONG_CLIENT_HOME $SONG_HOME \
+    && chown -R $SONG_UID:$SONG_GID $SONG_CLIENT_HOME $SONG_HOME \
 	&& apk add bash
 
 COPY song-client/target/song-client-*-dist.tar.gz  /song-client.tar.gz
@@ -27,8 +28,7 @@ RUN tar zxvf song-client.tar.gz -C /tmp \
 	&& touch $CLIENT_DIST_DIR/logs/client.log \
 	&& chmod 777 $CLIENT_DIST_DIR/logs/client.log \
 	&& mv $CLIENT_DIST_DIR/* $SONG_CLIENT_HOME \
-	&& chown -R $SONG_UID:$SONG_GID $SONG_CLIENT_HOME \
-	&& chmod -R 777 $SONG_CLIENT_HOME/logs
+	&& chown -R $SONG_UID:$SONG_GID $SONG_CLIENT_HOME
 
 
 # Set working directory for convenience with interactive usage


### PR DESCRIPTION
There are 2 main features with the client image that are needed:
- ability for main process to write to mounted docker host directories
- main process must run as non-root user

Issue:
- created `song` user with UID/GID 9999
- log directory is owned `song` user
- mounted docker host dir. Docker mounts the directory as uid/gid 1000
- main process run as `song` user
- main process could write to log directory but could not write to the mounted directory

This PR allows for the main process to write to the logs directory and mounted directory

