### PR TITLE
Feat/90 jwt to score

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,7 +145,7 @@ services:
       target: server
     environment:
       SERVER_PORT: 8080
-      SPRING_PROFILES_ACTIVE: "prod,secure,default,jwt"
+      SPRING_PROFILES_ACTIVE: "prod,secure,default,jwt,storageClientCred"
       AUTH_JWT_PUBLICKEYURL: http://ego-api:8080/oauth/token/public_key
       AUTH_SERVER_URL: http://ego-api:8080/o/check_api_key/
       AUTH_SERVER_CLIENTID: song
@@ -155,11 +155,10 @@ services:
       AUTH_SERVER_SCOPE_STUDY_SUFFIX: .WRITE
       AUTH_SERVER_SCOPE_SYSTEM: song.WRITE
       SCORE_URL: http://score-server:8080
-      SCORE_ACCESSTOKEN: "NO LONGER NEEDED"
-      SCORE_CLIENTCREDENTIALS_ENABLED: "true"
       SCORE_CLIENTCREDENTIALS_ID: oauth
       SCORE_CLIENTCREDENTIALS_SECRET: oauthsecret
       SCORE_CLIENTCREDENTIALS_TOKENURL: http://ego-api:8080/oauth/token
+      SCORE_CLIENTCREDENTIALS_SYSTEMSCOPE: "score.WRITE"
       MANAGEMENT_SERVER_PORT: 8081
       SPRING_DATASOURCE_USERNAME: postgres
       SPRING_DATASOURCE_PASSWORD: password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   ego-api:
-    image: "overture/ego:3.1.0"
+    image: "overture/ego:3.3.0"
     environment:
       SERVER_PORT: 8080
       SPRING_DATASOURCE_URL: jdbc:postgresql://ego-postgres:5432/ego?stringtype=unspecified
@@ -10,11 +10,11 @@ services:
       SPRING_FLYWAY_ENABLED: "true"
       SPRING_FLYWAY_LOCATIONS: "classpath:flyway/sql,classpath:db/migration"
       SPRING_PROFILES: demo, auth
+      JWT_DURATIONMS: 300000 # expire tokens in 5 min for local testing
     expose:
       - "8080"
     ports:
       - "9082:8080"
-    command: java -jar /srv/ego/install/ego.jar
     depends_on:
       - ego-postgres
   ego-postgres:
@@ -43,10 +43,10 @@ services:
     ports:
       - "8085:9000"
   score-server:
-    image: overture/score-server:5.0.0
+    image: overture/score-server:5.1.0
     user: "$MY_UID:$MY_GID"
     environment:
-      SPRING_PROFILES_ACTIVE: amazon,collaboratory,prod,secure
+      SPRING_PROFILES_ACTIVE: amazon,collaboratory,prod,secure,jwt
       SERVER_PORT: 8080
       OBJECT_SENTINEL: heliograph
       BUCKET_NAME_OBJECT: oicr.icgc.test
@@ -57,6 +57,7 @@ services:
       S3_ACCESSKEY: minio
       S3_SECRETKEY: minio123
       S3_SIGV4ENABLED: "true"
+      AUTH_JWT_PUBLICKEYURL: http://ego-api:8080/oauth/token/public_key
       AUTH_SERVER_URL: http://ego-api:8080/o/check_api_key/
       AUTH_SERVER_CLIENTID: score
       AUTH_SERVER_CLIENTSECRET: scoresecret
@@ -144,7 +145,8 @@ services:
       target: server
     environment:
       SERVER_PORT: 8080
-      SPRING_PROFILES_ACTIVE: "prod,secure,default"
+      SPRING_PROFILES_ACTIVE: "prod,secure,default,jwt"
+      AUTH_JWT_PUBLICKEYURL: http://ego-api:8080/oauth/token/public_key
       AUTH_SERVER_URL: http://ego-api:8080/o/check_api_key/
       AUTH_SERVER_CLIENTID: song
       AUTH_SERVER_TOKENNAME: apiKey
@@ -153,7 +155,11 @@ services:
       AUTH_SERVER_SCOPE_STUDY_SUFFIX: .WRITE
       AUTH_SERVER_SCOPE_SYSTEM: song.WRITE
       SCORE_URL: http://score-server:8080
-      SCORE_ACCESSTOKEN: f69b726d-d40f-4261-b105-1ec7e6bf04d5
+      SCORE_ACCESSTOKEN: "NO LONGER NEEDED"
+      SCORE_CLIENTCREDENTIALS_ENABLED: "true"
+      SCORE_CLIENTCREDENTIALS_ID: oauth
+      SCORE_CLIENTCREDENTIALS_SECRET: oauthsecret
+      SCORE_CLIENTCREDENTIALS_TOKENURL: http://ego-api:8080/oauth/token
       MANAGEMENT_SERVER_PORT: 8081
       SPRING_DATASOURCE_USERNAME: postgres
       SPRING_DATASOURCE_PASSWORD: password

--- a/docker/ego-init/init.sql
+++ b/docker/ego-init/init.sql
@@ -295,6 +295,7 @@ ALTER TABLE public.userpermission OWNER TO postgres;
 --
 
 COPY public.egoapplication (name, clientid, clientsecret, redirecturi, description, status, id, type) FROM stdin;
+oauth2-resource	oauth	oauthsecret	http://example.com	song	APPROVED	77f1ef78-7495-4b4a-982a-6b9532dc69fb	CLIENT
 \.
 
 
@@ -344,6 +345,7 @@ COPY public.flyway_schema_history (installed_rank, version, description, type, s
 --
 
 COPY public.groupapplication (group_id, application_id) FROM stdin;
+f2885e96-f74e-4f7a-b935-fb48b18e761d	77f1ef78-7495-4b4a-982a-6b9532dc69fb
 \.
 
 

--- a/song-server/src/main/java/bio/overture/song/server/config/StorageClientCredConfig.java
+++ b/song-server/src/main/java/bio/overture/song/server/config/StorageClientCredConfig.java
@@ -1,0 +1,66 @@
+package bio.overture.song.server.config;
+
+import bio.overture.song.server.service.StorageService;
+import bio.overture.song.server.service.ValidationService;
+import java.util.List;
+import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.security.oauth2.client.DefaultOAuth2ClientContext;
+import org.springframework.security.oauth2.client.OAuth2RestTemplate;
+import org.springframework.security.oauth2.client.token.grant.client.ClientCredentialsResourceDetails;
+import org.springframework.web.client.RestTemplate;
+
+@NoArgsConstructor
+@Configuration
+@Profile("storageClientCred")
+public class StorageClientCredConfig {
+
+  @Autowired private RetryTemplate retryTemplate;
+
+  @Autowired private ValidationService validationService;
+
+  @Value("${score.url}")
+  private String storageUrl;
+
+  @Value("${score.clientCredentials.id}")
+  private String clientId;
+
+  @Value("${score.clientCredentials.secret}")
+  private String clientSecret;
+
+  @Value("${score.clientCredentials.tokenUrl}")
+  private String tokenUrl;
+
+  @Value("${score.clientCredentials.systemScope}")
+  private String systemScope;
+
+  @Primary
+  @Bean
+  public StorageService storageService() {
+    return StorageService.builder()
+        .restTemplate(oauth2ClientCredentialsRestTempalate())
+        .retryTemplate(retryTemplate)
+        .storageUrl(storageUrl)
+        .validationService(validationService)
+        .build();
+  }
+
+  private RestTemplate oauth2ClientCredentialsRestTempalate() {
+    ClientCredentialsResourceDetails resource = new ClientCredentialsResourceDetails();
+
+    resource.setAccessTokenUri(tokenUrl);
+    resource.setClientId(clientId);
+    resource.setClientSecret(clientSecret);
+    resource.setScope(List.of(systemScope));
+
+    DefaultOAuth2ClientContext clientContext = new DefaultOAuth2ClientContext();
+
+    return new OAuth2RestTemplate(resource, clientContext);
+  }
+}

--- a/song-server/src/main/resources/application.yml
+++ b/song-server/src/main/resources/application.yml
@@ -29,11 +29,6 @@ score:
   # Require both upload and download scopes
   accessToken: "ad83ebde-a55c-11e7-abc4-cec278b6b50a"
   url: "http://localhost:8087"
-  clientCredentials:
-    enabled: false
-    id: oauth
-    secret: oauthsecret
-    tokenUrl: http://ego-api:8080/oauth/token
 
 # Hibernate
 spring:
@@ -252,3 +247,13 @@ spring:
 auth:
   jwt:
     public-key-url: http://localhost:8084/oauth/token/public_key
+
+---
+spring.profiles: storageClientCred
+score:
+  url: "http://localhost:8087"
+  clientCredentials:
+    id: oauth
+    secret: oauthsecret
+    tokenUrl: http://ego-api:8080/oauth/token
+    systemScope: "score.WRITE" # Storage scope needs to include both READ and WRITE

--- a/song-server/src/main/resources/application.yml
+++ b/song-server/src/main/resources/application.yml
@@ -29,6 +29,11 @@ score:
   # Require both upload and download scopes
   accessToken: "ad83ebde-a55c-11e7-abc4-cec278b6b50a"
   url: "http://localhost:8087"
+  clientCredentials:
+    enabled: false
+    id: oauth
+    secret: oauthsecret
+    tokenUrl: http://ego-api:8080/oauth/token
 
 # Hibernate
 spring:

--- a/song-server/src/test/java/bio/overture/song/server/service/StorageServiceTest.java
+++ b/song-server/src/test/java/bio/overture/song/server/service/StorageServiceTest.java
@@ -80,7 +80,6 @@ public class StorageServiceTest {
             .retryTemplate(retryTemplate)
             .storageUrl(testStorageUrl)
             .validationService(validationService)
-            .scoreAuthorizationHeader(DEFAULT_ACCESS_TOKEN)
             .build();
   }
 


### PR DESCRIPTION
Proposed changes:
- refactor StorageService to not take authorization header and rather take RestTemplate with authorization injected
- Add new profile for client credentials flow to storage/score
- update docker dev setup to reflect new change

Opening PR but with a caveat, see my comment.