### PR TITLE
Recalculate publish dates after publish state change

### DIFF
--- a/song-server/src/main/java/bio/overture/song/server/service/analysis/AnalysisServiceImpl.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/analysis/AnalysisServiceImpl.java
@@ -300,6 +300,8 @@ public class AnalysisServiceImpl implements AnalysisService {
     checkAnalysisAndStudyRelated(studyId, id);
 
     val a = unsecuredDeepRead(id);
+
+    // Validations before publishing
     val analysisSchema = a.getAnalysisSchema();
     checkAnalysisTypeVersion(analysisSchema);
     val files = a.getFiles();
@@ -307,8 +309,13 @@ public class AnalysisServiceImpl implements AnalysisService {
     val file2storageObjectMap = getStorageObjectsForFiles(files);
     checkMismatchingFileSizes(id, file2storageObjectMap);
     checkMismatchingFileMd5sums(id, file2storageObjectMap, ignoreUndefinedMd5);
+
+    // Publish
     checkedUpdateState(id, PUBLISHED);
 
+    // Recalculate publish times now that it has a new PUBLISHED state in history
+    a.populatePublishTimes();
+    
     return a;
   }
 


### PR DESCRIPTION
## Problem
Kafka messages after SONG Publish events were missing the Publish date property values. 

## Solution
This was because the calculations on the returned analysis were done before the PUBLISH state change, and not calculated once the analysis was set to PUBLISHED afterwards. One line added to calculate the publish date properties in the AnalysisService.publish() method before returning the analysis. This returned analysis is used to build the Kafka message.