### PR TITLE
new getAnalysis endpoint with pagination

### DIFF
--- a/song-server/src/main/java/bio/overture/song/server/controller/AnalysisController.java
+++ b/song-server/src/main/java/bio/overture/song/server/controller/AnalysisController.java
@@ -27,6 +27,7 @@ import bio.overture.song.server.model.analysis.Analysis;
 import bio.overture.song.server.model.entity.FileEntity;
 import bio.overture.song.server.repository.search.IdSearchRequest;
 import bio.overture.song.server.service.analysis.AnalysisService;
+import bio.overture.song.server.service.analysis.GetAnalysisResponse;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableSet;
 import io.swagger.annotations.Api;
@@ -85,9 +86,25 @@ public class AnalysisController {
   public List<Analysis> getAnalysis(
       @PathVariable("studyId") String studyId,
       @ApiParam(value = "Non-empty comma separated list of analysis states to filter by")
-          @RequestParam(value = "analysisStates", defaultValue = "PUBLISHED", required = false)
+      @RequestParam(value = "analysisStates", defaultValue = "PUBLISHED", required = false)
           String analysisStates) {
     return analysisService.getAnalysis(studyId, ImmutableSet.copyOf(COMMA.split(analysisStates)));
+  }
+
+  @ApiOperation(
+      value = "GetAnalysesForStudy",
+      notes = "Retrieve paginated analysis objects for a studyId, default first page is page 0," +
+          "default page size is 20. Results are sorted by analysis id ASC order.")
+  @GetMapping(value = "/paginated")
+  public GetAnalysisResponse getAnalysis(
+      @PathVariable("studyId") String studyId,
+      @ApiParam(value = "Non-empty comma separated list of analysis states to filter by")
+      @RequestParam(value = "analysisStates", defaultValue = "PUBLISHED", required = false)
+        String analysisStates,
+      @RequestParam(value = "page", defaultValue = "0", required = false) int page,
+      @RequestParam(value = "size", defaultValue = "20", required = false) int size) {
+    return analysisService.getAnalysis(
+        studyId, ImmutableSet.copyOf(COMMA.split(analysisStates)), page, size);
   }
 
   /** [DCC-5726] - non-dynamic updates disabled until hibernate is properly integrated */

--- a/song-server/src/main/java/bio/overture/song/server/repository/specification/AnalysisSpecificationBuilder.java
+++ b/song-server/src/main/java/bio/overture/song/server/repository/specification/AnalysisSpecificationBuilder.java
@@ -85,12 +85,12 @@ public class AnalysisSpecificationBuilder {
     return builder.equal(root.get(ModelAttributeNames.ANALYSIS_ID), analysisId);
   }
 
-  private static Predicate whereStatesInPredicate(
+  public static Predicate whereStatesInPredicate(
       Root<Analysis> root, Collection<String> analysisStates) {
     return root.get(ModelAttributeNames.ANALYSIS_STATE).in(analysisStates);
   }
 
-  private static Predicate equalsStudyPredicate(
+  public static Predicate equalsStudyPredicate(
       Root<Analysis> root, CriteriaBuilder builder, String study) {
     return builder.equal(root.get(STUDY_ID), study);
   }

--- a/song-server/src/main/java/bio/overture/song/server/repository/specification/AnalysisSpecificationBuilder.java
+++ b/song-server/src/main/java/bio/overture/song/server/repository/specification/AnalysisSpecificationBuilder.java
@@ -51,8 +51,10 @@ public class AnalysisSpecificationBuilder {
   public Specification<Analysis> buildSpec(
       @NonNull String study, @NonNull Collection<String> analysisStates) {
     return (fromUser, query, builder) -> {
-      // The reason for having this check is because of the issue: https://github.com/spring-projects/spring-data-jpa/issues/532
-      // in order to avoid the hibernate error and perform a fetch join, do not apply fetch join criteria
+      // The reason for having this check is because of the issue:
+      // https://github.com/spring-projects/spring-data-jpa/issues/532
+      // in order to avoid the hibernate error and perform a fetch join, do not apply fetch join
+      // criteria
       // on count query. If the result type is long, that means a count query is fired.
       if (!query.getResultType().equals(Long.class)) {
         fromUser.fetch(ANALYSIS_SCHEMA, LEFT);
@@ -60,7 +62,8 @@ public class AnalysisSpecificationBuilder {
       }
       query.distinct(true);
       return builder.and(
-          equalsStudyPredicate(fromUser, builder, study), whereStatesInPredicate(fromUser, analysisStates));
+          equalsStudyPredicate(fromUser, builder, study),
+          whereStatesInPredicate(fromUser, analysisStates));
     };
   }
 

--- a/song-server/src/main/java/bio/overture/song/server/service/analysis/AnalysisService.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/analysis/AnalysisService.java
@@ -20,6 +20,8 @@ public interface AnalysisService {
 
   List<Analysis> getAnalysis(String studyId, Set<String> analysisStates);
 
+  GetAnalysisResponse getAnalysis(String studyId, Set<String> analysisStates, int page, int size);
+
   List<Analysis> idSearch(String studyId, IdSearchRequest request);
 
   boolean isAnalysisExist(String id);

--- a/song-server/src/main/java/bio/overture/song/server/service/analysis/AnalysisServiceImpl.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/analysis/AnalysisServiceImpl.java
@@ -39,8 +39,6 @@ import static bio.overture.song.core.utils.JsonUtils.readTree;
 import static bio.overture.song.core.utils.JsonUtils.toJsonNode;
 import static bio.overture.song.core.utils.Separators.COMMA;
 import static bio.overture.song.server.model.enums.ModelAttributeNames.*;
-import static bio.overture.song.server.repository.specification.AnalysisSpecificationBuilder.equalsStudyPredicate;
-import static bio.overture.song.server.repository.specification.AnalysisSpecificationBuilder.whereStatesInPredicate;
 import static bio.overture.song.server.utils.JsonSchemas.PROPERTIES;
 import static bio.overture.song.server.utils.JsonSchemas.REQUIRED;
 import static bio.overture.song.server.utils.JsonSchemas.buildSchema;
@@ -49,7 +47,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.lang.String.format;
 import static java.util.Objects.isNull;
-import static javax.persistence.criteria.JoinType.LEFT;
 
 import bio.overture.song.core.model.AnalysisTypeId;
 import bio.overture.song.core.model.enums.AnalysisStates;
@@ -84,10 +81,6 @@ import java.time.LocalDateTime;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
 import javax.transaction.Transactional;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -98,7 +91,6 @@ import org.everit.json.schema.ValidationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 @Slf4j

--- a/song-server/src/main/java/bio/overture/song/server/service/analysis/AnalysisServiceSender.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/analysis/AnalysisServiceSender.java
@@ -88,6 +88,12 @@ public class AnalysisServiceSender implements AnalysisService {
   }
 
   @Override
+  public GetAnalysisResponse getAnalysis(
+      String studyId, Set<String> analysisStates, int page, int size) {
+    return internalAnalysisService.getAnalysis(studyId, analysisStates, page, size);
+  }
+
+  @Override
   public List<Analysis> idSearch(String studyId, IdSearchRequest request) {
     return internalAnalysisService.idSearch(studyId, request);
   }

--- a/song-server/src/main/java/bio/overture/song/server/service/analysis/GetAnalysisResponse.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/analysis/GetAnalysisResponse.java
@@ -1,0 +1,18 @@
+package bio.overture.song.server.service.analysis;
+
+import bio.overture.song.server.model.analysis.Analysis;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+import java.util.List;
+
+@Builder
+@Value
+public class GetAnalysisResponse {
+  @NonNull private List<Analysis> analyses;
+  @NonNull private long totalAnalyses;
+  @NonNull private int totalPages;
+  @NonNull private int currentTotalAnalyses;
+  @NonNull private boolean hasNext;
+}

--- a/song-server/src/main/java/bio/overture/song/server/service/analysis/GetAnalysisResponse.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/analysis/GetAnalysisResponse.java
@@ -1,18 +1,17 @@
 package bio.overture.song.server.service.analysis;
 
 import bio.overture.song.server.model.analysis.Analysis;
+import java.util.List;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
-
-import java.util.List;
 
 @Builder
 @Value
 public class GetAnalysisResponse {
   @NonNull private List<Analysis> analyses;
-  @NonNull private long totalAnalyses;
-  @NonNull private int totalPages;
-  @NonNull private int currentTotalAnalyses;
-  @NonNull private boolean hasNext;
+  private long totalAnalyses;
+  private int totalPages;
+  private int currentTotalAnalyses;
+  private boolean hasNext;
 }


### PR DESCRIPTION
This pr adds a new `getAnalysis` endpoint that has pagination. 
- no change made to the old `getAnalysis`, we can migrate to the new paginated endpoint after it's tested.
- The paginated endpoint takes a `page` and a `size` query params.