### PR TITLE
Add fileType TXT to base schema and file_type enum

### DIFF
--- a/song-server/src/main/resources/db/migration/V1_9__filetype_enum_add_txt.sql
+++ b/song-server/src/main/resources/db/migration/V1_9__filetype_enum_add_txt.sql
@@ -1,0 +1,20 @@
+ALTER TYPE file_type RENAME TO _file_type;
+CREATE TYPE file_type as ENUM('FASTA','FAI','FASTQ','BAM','BAI','VCF','TBI','IDX','XML','TGZ','CRAM','CRAI','TXT');
+ALTER TABLE file RENAME COLUMN type TO _type;
+ALTER TABLE file ADD COLUMN type file_type;
+
+UPDATE file SET type='FASTA' where _type='FASTA';
+UPDATE file SET type='FAI'   where _type='FAI';
+UPDATE file SET type='FASTQ' where _type='FASTQ';
+UPDATE file SET type='BAM'   where _type='BAM';
+UPDATE file SET type='BAI'   where _type='BAI';
+UPDATE file SET type='VCF'   where _type='VCF';
+UPDATE file SET type='TBI'   where _type='TBI';
+UPDATE file SET type='IDX'   where _type='IDX';
+UPDATE file SET type='XML'   where _type='XML';
+UPDATE file SET type='TGZ'   where _type='TGZ';
+UPDATE file SET type='CRAM'   where _type='CRAM';
+UPDATE file SET type='CRAI'   where _type='CRAI';
+
+ALTER TABLE file DROP COLUMN _type;
+DROP TYPE _file_type CASCADE;

--- a/song-server/src/main/resources/schemas/analysis/analysisBase.json
+++ b/song-server/src/main/resources/schemas/analysis/analysisBase.json
@@ -1,276 +1,260 @@
 {
-	"$schema": "http://json-schema.org/draft-07/schema#",
-	"id": "analysisPayload",
-	"type": "object",
-	"definitions": {
-		"common" : {
-			"md5" : {
-				"type": "string",
-				"pattern" : "^[a-fA-F0-9]{32}$"
-			},
-			"submitterId" : {
-				"type": "string",
-				"pattern": "^[A-Za-z0-9\\-\\._]{1,64}$"
-			},
-			"info" : {
-				"type": "object"
-			}
-		},
-		"file" : {
-			"fileType": {
-				"type": "string",
-				"enum": [
-					"FASTA",
-					"FAI",
-					"FASTQ",
-					"BAM",
-					"BAI",
-					"VCF",
-					"TBI",
-					"IDX",
-					"XML",
-					"TGZ",
-					"CRAM",
-					"CRAI"
-				]
-			},
-			"fileData" :{
-				"type": "object",
-				"required": [
-					"dataType",
-					"fileName",
-					"fileSize",
-					"fileType",
-					"fileAccess",
-					"fileMd5sum"
-				],
-				"properties": {
-					"dataType": {
-						"type": "string"
-					},
-					"fileName": {
-						"type": "string",
-						"pattern": "^[A-Za-z0-9_\\.\\-\\[\\]\\(\\)]+$"
-					},
-					"fileSize": {
-						"type": "integer",
-						"min" : 0
-					},
-					"fileAccess" : {
-						"type" : "string",
-						"enum" : [
-							"open",
-							"controlled"
-						]
-					},
-					"fileType": { "$ref" : "#/definitions/file/fileType" },
-					"fileMd5sum": { "$ref" : "#/definitions/common/md5" },
-					"info" :  { "$ref" : "#/definitions/common/info" }
-				}
-			}
-		},
-		"donor" : {
-			"gender": {
-				"type": "string",
-				"enum": [
-					"Male",
-					"Female",
-					"Other"
-				]
-			},
-			"donorData": {
-				"type": "object",
-				"required" : [
-					"submitterDonorId",
-					"gender"
-				],
-				"properties": {
-					"submitterDonorId": { "$ref" : "#/definitions/common/submitterId" },
-					"gender": { "$ref" : "#/definitions/donor/gender"},
-					"info": { "$ref" : "#/definitions/common/info"}
-				}
-			}
-		},
-		"specimen": {
-            "specimenTissueSource" : {
-				"type" : "string",
-				"enum" : [
-					"Blood derived",
-					"Blood derived - bone marrow",
-					"Blood derived - peripheral blood",
-					"Bone marrow",
-					"Buccal cell",
-					"Lymph node",
-					"Solid tissue",
-					"Plasma",
-					"Serum",
-					"Urine",
-					"Cerebrospinal fluid",
-					"Sputum",
-					"Other",
-					"Pleural effusion",
-					"Mononuclear cells from bone marrow",
-					"Saliva",
-					"Skin",
-					"Intestine",
-					"Buffy coat",
-					"Stomach",
-					"Esophagus",
-					"Tonsil",
-					"Spleen",
-					"Bone",
-					"Cerebellum",
-					"Endometrium"
-				]
-			},
-			"specimenType": {
-				"type": "string",
-				"enum": [
-					"Normal",
-					"Normal - tissue adjacent to primary tumour",
-					"Primary tumour",
-					"Primary tumour - adjacent to normal",
-					"Primary tumour - additional new primary",
-					"Recurrent tumour",
-					"Metastatic tumour",
-					"Metastatic tumour - metastasis local to lymph node",
-					"Metastatic tumour - metastasis to distant location",
-					"Metastatic tumour - additional metastatic",
-					"Xenograft - derived from primary tumour",
-					"Xenograft - derived from tumour cell line",
-					"Cell line - derived from xenograft tumour",
-					"Cell line - derived from tumour",
-					"Cell line - derived from normal"
-				]
-			},
-			"tumourNormalDesignation" : {
-				"type": "string",
-				"enum": [
-					"Normal",
-					"Tumour"
-				]
-			},
-			"specimenData": {
-				"type": "object",
-				"required" : [
-					"submitterSpecimenId",
-					"specimenTissueSource",
-					"tumourNormalDesignation",
-					"specimenType"
-				],
-				"properties": {
-					"submitterSpecimenId": { "$ref" : "#/definitions/common/submitterId" },
-					"specimenTissueSource" : { "$ref" : "#/definitions/specimen/specimenTissueSource" },
-					"tumourNormalDesignation" : { "$ref" : "#/definitions/specimen/tumourNormalDesignation" },
-					"specimenType" : { "$ref" : "#/definitions/specimen/specimenType" },
-					"specimenClass": {
-						"not" : {}
-					},
-					"info": { "$ref" : "#/definitions/common/info"}
-				}
-			}
-		},
-		"analysisType" : {
-			"type": "object",
-            "required": ["name"],
-			"properties": {
-				"name" : {
-					"type" : "string"
-				},
-				"version": {
-					"type" : ["integer","null"]
-				}
-			}
-		},
-		"sample" : {
-			"sampleTypes" :{
-				"type": "string",
-				"enum": [
-					"Total DNA",
-					"Amplified DNA",
-					"ctDNA",
-					"Other DNA enrichments",
-					"Total RNA",
-					"Ribo-Zero RNA",
-					"polyA+ RNA",
-					"Other RNA fractions"
-				]
-			},
-			"sampleData": {
-				"type": "object",
-				"required": [
-					"submitterSampleId",
-					"sampleType"
-				],
-				"properties": {
-					"submitterSampleId": { "$ref" : "#/definitions/common/submitterId" },
-					"sampleType": { "$ref" : "#/definitions/sample/sampleTypes" },
-					"info": { "$ref" : "#/definitions/common/info"}
-				}
-			}
-		}
-	},
-	"required": [ "studyId", "analysisType", "samples","files"],
-	"properties": {
-		"analysisId" :{
-			"not" : {}
-		},
-		"studyId" : {
-			"type": "string",
-			"minLength": 1
-		},
-		"analysisType": {
-			"allOf": [{"$ref" :  "#/definitions/analysisType"}]
-		},
-		"samples": {
-			"type": "array",
-			"minItems" : 1,
-			"items": {
-				"type": "object",
-				"allOf" : [
-					{"$ref" : "#/definitions/sample/sampleData" }
-				],
-				"required": [
-					"specimen",
-					"donor"
-				],
-				"properties": {
-					"specimen": { "$ref" : "#/definitions/specimen/specimenData" },
-					"donor": { "$ref" : "#/definitions/donor/donorData" }
-				},
-				"if" : {
-					"properties" : {
-						"specimen": {
-							"properties": {
-								"tumourNormalDesignation" : {
-									"const" : "Tumour"
-								}
-							}
-						}
-					}
-				},
-				"then" : {
-					"properties" : {
-						"matchedNormalSubmitterSampleId" : {
-							"$ref" : "#/definitions/common/submitterId"
-						}
-					},
-					"required": ["matchedNormalSubmitterSampleId"]
-				},
-				"else" : {
-					"properties" : {
-						"matchedNormalSubmitterSampleId": {
-							"const" : null
-						}
-					},
-					"required": ["matchedNormalSubmitterSampleId"]
-				}
-			}
-		},
-		"files": {
-			"type": "array",
-			"minItems" : 1,
-			"items": { "$ref" : "#/definitions/file/fileData" }
-		}
-	}
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "analysisPayload",
+  "type": "object",
+  "definitions": {
+    "common": {
+      "md5": {
+        "type": "string",
+        "pattern": "^[a-fA-F0-9]{32}$"
+      },
+      "submitterId": {
+        "type": "string",
+        "pattern": "^[A-Za-z0-9\\-\\._]{1,64}$"
+      },
+      "info": {
+        "type": "object"
+      }
+    },
+    "file": {
+      "fileType": {
+        "type": "string",
+        "enum": [
+          "FASTA",
+          "FAI",
+          "FASTQ",
+          "BAM",
+          "BAI",
+          "VCF",
+          "TBI",
+          "IDX",
+          "XML",
+          "TGZ",
+          "CRAM",
+          "CRAI",
+          "TXT"
+        ]
+      },
+      "fileData": {
+        "type": "object",
+        "required": [
+          "dataType",
+          "fileName",
+          "fileSize",
+          "fileType",
+          "fileAccess",
+          "fileMd5sum"
+        ],
+        "properties": {
+          "dataType": {
+            "type": "string"
+          },
+          "fileName": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_\\.\\-\\[\\]\\(\\)]+$"
+          },
+          "fileSize": {
+            "type": "integer",
+            "min": 0
+          },
+          "fileAccess": {
+            "type": "string",
+            "enum": ["open", "controlled"]
+          },
+          "fileType": { "$ref": "#/definitions/file/fileType" },
+          "fileMd5sum": { "$ref": "#/definitions/common/md5" },
+          "info": { "$ref": "#/definitions/common/info" }
+        }
+      }
+    },
+    "donor": {
+      "gender": {
+        "type": "string",
+        "enum": ["Male", "Female", "Other"]
+      },
+      "donorData": {
+        "type": "object",
+        "required": ["submitterDonorId", "gender"],
+        "properties": {
+          "submitterDonorId": { "$ref": "#/definitions/common/submitterId" },
+          "gender": { "$ref": "#/definitions/donor/gender" },
+          "info": { "$ref": "#/definitions/common/info" }
+        }
+      }
+    },
+    "specimen": {
+      "specimenTissueSource": {
+        "type": "string",
+        "enum": [
+          "Blood derived",
+          "Blood derived - bone marrow",
+          "Blood derived - peripheral blood",
+          "Bone marrow",
+          "Buccal cell",
+          "Lymph node",
+          "Solid tissue",
+          "Plasma",
+          "Serum",
+          "Urine",
+          "Cerebrospinal fluid",
+          "Sputum",
+          "Other",
+          "Pleural effusion",
+          "Mononuclear cells from bone marrow",
+          "Saliva",
+          "Skin",
+          "Intestine",
+          "Buffy coat",
+          "Stomach",
+          "Esophagus",
+          "Tonsil",
+          "Spleen",
+          "Bone",
+          "Cerebellum",
+          "Endometrium"
+        ]
+      },
+      "specimenType": {
+        "type": "string",
+        "enum": [
+          "Normal",
+          "Normal - tissue adjacent to primary tumour",
+          "Primary tumour",
+          "Primary tumour - adjacent to normal",
+          "Primary tumour - additional new primary",
+          "Recurrent tumour",
+          "Metastatic tumour",
+          "Metastatic tumour - metastasis local to lymph node",
+          "Metastatic tumour - metastasis to distant location",
+          "Metastatic tumour - additional metastatic",
+          "Xenograft - derived from primary tumour",
+          "Xenograft - derived from tumour cell line",
+          "Cell line - derived from xenograft tumour",
+          "Cell line - derived from tumour",
+          "Cell line - derived from normal"
+        ]
+      },
+      "tumourNormalDesignation": {
+        "type": "string",
+        "enum": ["Normal", "Tumour"]
+      },
+      "specimenData": {
+        "type": "object",
+        "required": [
+          "submitterSpecimenId",
+          "specimenTissueSource",
+          "tumourNormalDesignation",
+          "specimenType"
+        ],
+        "properties": {
+          "submitterSpecimenId": { "$ref": "#/definitions/common/submitterId" },
+          "specimenTissueSource": {
+            "$ref": "#/definitions/specimen/specimenTissueSource"
+          },
+          "tumourNormalDesignation": {
+            "$ref": "#/definitions/specimen/tumourNormalDesignation"
+          },
+          "specimenType": { "$ref": "#/definitions/specimen/specimenType" },
+          "specimenClass": {
+            "not": {}
+          },
+          "info": { "$ref": "#/definitions/common/info" }
+        }
+      }
+    },
+    "analysisType": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": ["integer", "null"]
+        }
+      }
+    },
+    "sample": {
+      "sampleTypes": {
+        "type": "string",
+        "enum": [
+          "Total DNA",
+          "Amplified DNA",
+          "ctDNA",
+          "Other DNA enrichments",
+          "Total RNA",
+          "Ribo-Zero RNA",
+          "polyA+ RNA",
+          "Other RNA fractions"
+        ]
+      },
+      "sampleData": {
+        "type": "object",
+        "required": ["submitterSampleId", "sampleType"],
+        "properties": {
+          "submitterSampleId": { "$ref": "#/definitions/common/submitterId" },
+          "sampleType": { "$ref": "#/definitions/sample/sampleTypes" },
+          "info": { "$ref": "#/definitions/common/info" }
+        }
+      }
+    }
+  },
+  "required": ["studyId", "analysisType", "samples", "files"],
+  "properties": {
+    "analysisId": {
+      "not": {}
+    },
+    "studyId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "analysisType": {
+      "allOf": [{ "$ref": "#/definitions/analysisType" }]
+    },
+    "samples": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "allOf": [{ "$ref": "#/definitions/sample/sampleData" }],
+        "required": ["specimen", "donor"],
+        "properties": {
+          "specimen": { "$ref": "#/definitions/specimen/specimenData" },
+          "donor": { "$ref": "#/definitions/donor/donorData" }
+        },
+        "if": {
+          "properties": {
+            "specimen": {
+              "properties": {
+                "tumourNormalDesignation": {
+                  "const": "Tumour"
+                }
+              }
+            }
+          }
+        },
+        "then": {
+          "properties": {
+            "matchedNormalSubmitterSampleId": {
+              "$ref": "#/definitions/common/submitterId"
+            }
+          },
+          "required": ["matchedNormalSubmitterSampleId"]
+        },
+        "else": {
+          "properties": {
+            "matchedNormalSubmitterSampleId": {
+              "const": null
+            }
+          },
+          "required": ["matchedNormalSubmitterSampleId"]
+        }
+      }
+    },
+    "files": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/file/fileData" }
+    }
+  }
 }

--- a/song-server/src/test/resources/documents/validation/dynamic-analysis-type/rendered-schema.json
+++ b/song-server/src/test/resources/documents/validation/dynamic-analysis-type/rendered-schema.json
@@ -3,16 +3,16 @@
   "id": "analysisPayload",
   "type": "object",
   "definitions": {
-    "common" : {
-      "md5" : {
+    "common": {
+      "md5": {
         "type": "string",
-        "pattern" : "^[a-fA-F0-9]{32}$"
+        "pattern": "^[a-fA-F0-9]{32}$"
       },
-      "submitterId" : {
+      "submitterId": {
         "type": "string",
         "pattern": "^[A-Za-z0-9\\-\\._]{1,64}$"
       },
-      "info" : {
+      "info": {
         "type": "object"
       }
     },
@@ -30,14 +30,15 @@
           "IDX",
           "XML",
           "TGZ",
-		  "CRAM",
-		  "CRAI"
+          "CRAM",
+          "CRAI",
+          "TXT"
         ]
       },
-      "fileData" :{
+      "fileData": {
         "type": "object",
         "required": [
-		  "dataType",
+          "dataType",
           "fileName",
           "fileSize",
           "fileType",
@@ -45,7 +46,7 @@
           "fileMd5sum"
         ],
         "properties": {
-          "dataType" : {
+          "dataType": {
             "type": "string"
           },
           "fileName": {
@@ -54,47 +55,37 @@
           },
           "fileSize": {
             "type": "integer",
-            "min" : 0
+            "min": 0
           },
-          "fileAccess" : {
-            "type" : "string",
-            "enum" : [
-              "open",
-              "controlled"
-            ]
+          "fileAccess": {
+            "type": "string",
+            "enum": ["open", "controlled"]
           },
-          "fileType": { "$ref" : "#/definitions/file/fileType" },
-          "fileMd5sum": { "$ref" : "#/definitions/common/md5" },
-          "info" :  { "$ref" : "#/definitions/common/info" }
+          "fileType": { "$ref": "#/definitions/file/fileType" },
+          "fileMd5sum": { "$ref": "#/definitions/common/md5" },
+          "info": { "$ref": "#/definitions/common/info" }
         }
       }
     },
-    "donor" : {
+    "donor": {
       "gender": {
         "type": "string",
-        "enum": [
-          "Male",
-          "Female",
-          "Other"
-        ]
+        "enum": ["Male", "Female", "Other"]
       },
       "donorData": {
         "type": "object",
-        "required" : [
-          "submitterDonorId",
-          "gender"
-        ],
+        "required": ["submitterDonorId", "gender"],
         "properties": {
-          "submitterDonorId": { "$ref" : "#/definitions/common/submitterId" },
-          "gender": { "$ref" : "#/definitions/donor/gender"},
-          "info": { "$ref" : "#/definitions/common/info"}
+          "submitterDonorId": { "$ref": "#/definitions/common/submitterId" },
+          "gender": { "$ref": "#/definitions/donor/gender" },
+          "info": { "$ref": "#/definitions/common/info" }
         }
       }
     },
     "specimen": {
-      "specimenTissueSource" : {
-        "type" : "string",
-        "enum" : [
+      "specimenTissueSource": {
+        "type": "string",
+        "enum": [
           "Blood derived",
           "Blood derived - bone marrow",
           "Blood derived - peripheral blood",
@@ -143,47 +134,48 @@
           "Cell line - derived from normal"
         ]
       },
-      "tumourNormalDesignation" : {
+      "tumourNormalDesignation": {
         "type": "string",
-        "enum": [
-          "Normal",
-          "Tumour"
-        ]
-	},
+        "enum": ["Normal", "Tumour"]
+      },
       "specimenData": {
         "type": "object",
-        "required" : [
+        "required": [
           "submitterSpecimenId",
           "specimenTissueSource",
           "tumourNormalDesignation",
-		  "specimenType"
+          "specimenType"
         ],
         "properties": {
-          "submitterSpecimenId": { "$ref" : "#/definitions/common/submitterId" },
-          "specimenTissueSource" : { "$ref" : "#/definitions/specimen/specimenTissueSource" },
-          "tumourNormalDesignation" : { "$ref" : "#/definitions/specimen/tumourNormalDesignation" },
-		  "specimenType" : { "$ref" : "#/definitions/specimen/specimenType" },
-          "specimenClass": {
-            "not" : {}
+          "submitterSpecimenId": { "$ref": "#/definitions/common/submitterId" },
+          "specimenTissueSource": {
+            "$ref": "#/definitions/specimen/specimenTissueSource"
           },
-          "info": { "$ref" : "#/definitions/common/info"}
+          "tumourNormalDesignation": {
+            "$ref": "#/definitions/specimen/tumourNormalDesignation"
+          },
+          "specimenType": { "$ref": "#/definitions/specimen/specimenType" },
+          "specimenClass": {
+            "not": {}
+          },
+          "info": { "$ref": "#/definitions/common/info" }
         }
       }
     },
-    "analysisType" : {
+    "analysisType": {
       "type": "object",
       "required": ["name"],
       "properties": {
-        "name" : {
-          "type" : "string"
+        "name": {
+          "type": "string"
         },
         "version": {
-          "type" : ["integer", "null"]
+          "type": ["integer", "null"]
         }
       }
     },
     "sample": {
-      "sampleTypes" :{
+      "sampleTypes": {
         "type": "string",
         "enum": [
           "Total DNA",
@@ -198,65 +190,66 @@
       },
       "sampleData": {
         "type": "object",
-        "required": [
-          "submitterSampleId",
-          "sampleType"
-        ],
+        "required": ["submitterSampleId", "sampleType"],
         "properties": {
-          "submitterSampleId": { "$ref" : "#/definitions/common/submitterId" },
-          "sampleType": { "$ref" : "#/definitions/sample/sampleTypes" },
-          "info": { "$ref" : "#/definitions/common/info"}
+          "submitterSampleId": { "$ref": "#/definitions/common/submitterId" },
+          "sampleType": { "$ref": "#/definitions/sample/sampleTypes" },
+          "info": { "$ref": "#/definitions/common/info" }
         }
       }
     }
   },
-  "required": [ "studyId", "analysisType","experiment","samples","files", "firstName"],
+  "required": [
+    "studyId",
+    "analysisType",
+    "experiment",
+    "samples",
+    "files",
+    "firstName"
+  ],
   "properties": {
-    "analysisId" : {
-      "not" : {}
+    "analysisId": {
+      "not": {}
     },
-    "studyId" : {
+    "studyId": {
       "type": "string",
       "minLength": 1
     },
     "analysisType": {
-      "allOf": [{"$ref" :  "#/definitions/analysisType"}]
+      "allOf": [{ "$ref": "#/definitions/analysisType" }]
     },
     "samples": {
       "type": "array",
-      "minItems" : 1,
+      "minItems": 1,
       "items": {
         "type": "object",
-        "allOf" : [ {"$ref" : "#/definitions/sample/sampleData" } ],
-        "required": [
-          "specimen",
-          "donor"
-        ],
+        "allOf": [{ "$ref": "#/definitions/sample/sampleData" }],
+        "required": ["specimen", "donor"],
         "properties": {
-          "specimen": { "$ref" : "#/definitions/specimen/specimenData" },
-          "donor": { "$ref" : "#/definitions/donor/donorData" }
+          "specimen": { "$ref": "#/definitions/specimen/specimenData" },
+          "donor": { "$ref": "#/definitions/donor/donorData" }
         },
-        "if" : {
-          "properties" : {
+        "if": {
+          "properties": {
             "specimen": {
               "properties": {
-                "tumourNormalDesignation" : {
-                  "const" : "Tumour"
+                "tumourNormalDesignation": {
+                  "const": "Tumour"
                 }
               }
             }
           }
         },
-        "then" : {
-          "properties" : {
-            "matchedNormalSubmitterSampleId" : {
-              "$ref" : "#/definitions/common/submitterId"
+        "then": {
+          "properties": {
+            "matchedNormalSubmitterSampleId": {
+              "$ref": "#/definitions/common/submitterId"
             }
           },
           "required": ["matchedNormalSubmitterSampleId"]
         },
-        "else" : {
-          "properties" : {
+        "else": {
+          "properties": {
             "matchedNormalSubmitterSampleId": {
               "const": null
             }
@@ -267,21 +260,19 @@
     },
     "files": {
       "type": "array",
-      "minItems" : 1,
-      "items": { "$ref" : "#/definitions/file/fileData" }
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/file/fileData" }
     },
-    "experiment" : {
-      "type" : "object",
-      "properties" : {
-        "exp_name" : {
-          "type" : "string"
+    "experiment": {
+      "type": "object",
+      "properties": {
+        "exp_name": {
+          "type": "string"
         }
       }
     },
-    "firstName" : {
-      "type" : "string"
+    "firstName": {
+      "type": "string"
     }
   }
 }
-
-


### PR DESCRIPTION
Migration based on migration v1_4 which added CRAM and CRAI to the same enum. Since that worked previously this migration uses the same process copy and pasted with value updates.