### PR TITLE
add TRACE logging Hikari

### DIFF
--- a/song-server/src/main/resources/application.yml
+++ b/song-server/src/main/resources/application.yml
@@ -56,6 +56,9 @@ spring:
 
 logging:
   level:
+    com:
+      zaxxer:
+        hikari: TRACE
     io:
       swagger:
         models:

--- a/song-server/src/main/resources/application.yml
+++ b/song-server/src/main/resources/application.yml
@@ -52,7 +52,7 @@ spring:
     min-idle: 1
     initialization-mode: always
     hikari:
-      connection-timeout: 500
+      connection-timeout: 1000
 
 logging:
   level:
@@ -152,7 +152,7 @@ spring:
     max-idle: 1
     min-idle: 1
     hikari:
-      connection-timeout: 500
+      connection-timeout: 1000
       validation-timeout: 250
 
 id.persistInMemory: true
@@ -182,7 +182,7 @@ spring:
   datasource:
     initialization-mode: always
     hikari:
-      connection-timeout: 500
+      connection-timeout: 1000
 
 management:
   server:


### PR DESCRIPTION
Add logging for debugging SONG rdpc dev error: 
```
2022-03-03 23:14:13,639 [http-nio-8080-exec-11] ERROR o.a.c.c.C.[.[.[.[dispatcherServlet] - Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is org.springframework.transaction.CannotCreateTransactionException: Could not open JPA EntityManager for transaction; nested exception is org.hibernate.exception.JDBCConnectionException: Unable to acquire JDBC Connection] with root cause
java.sql.SQLTransientConnectionException: HikariPool-1 - Connection is not available, request timed out after 500ms.
```