### PR TITLE
Add analysisId as key to kafka messages

### DIFF
--- a/song-server/src/main/java/bio/overture/song/server/kafka/Sender.java
+++ b/song-server/src/main/java/bio/overture/song/server/kafka/Sender.java
@@ -19,5 +19,5 @@ package bio.overture.song.server.kafka;
 
 public interface Sender {
 
-  void send(String payload);
+    void send(String payload, String key);
 }

--- a/song-server/src/main/java/bio/overture/song/server/kafka/impl/KafkaSender.java
+++ b/song-server/src/main/java/bio/overture/song/server/kafka/impl/KafkaSender.java
@@ -27,10 +27,11 @@ import org.springframework.kafka.core.KafkaTemplate;
 @Slf4j
 public class KafkaSender implements Sender {
 
-  @Autowired private KafkaTemplate<String, String> kafkaTemplate;
+    @Autowired
+    private KafkaTemplate<String, String> kafkaTemplate;
 
-  public void send(String payload) {
-    log.debug("sending payload='{}' to topic='{}'", payload, kafkaTemplate.getDefaultTopic());
-    kafkaTemplate.send(kafkaTemplate.getDefaultTopic(), payload);
-  }
+    public void send(String payload, String key) {
+        log.debug("sending payload='{}' to topic='{}'", payload, kafkaTemplate.getDefaultTopic());
+        kafkaTemplate.send(kafkaTemplate.getDefaultTopic(), key, payload);
+    }
 }

--- a/song-server/src/main/java/bio/overture/song/server/kafka/impl/NoopSender.java
+++ b/song-server/src/main/java/bio/overture/song/server/kafka/impl/NoopSender.java
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class NoopSender implements Sender {
 
-  public void send(String payload) {
-    log.info("sending payload='{}' to no topic as kafka support is disabled", payload);
-  }
+    public void send(String payload, String _key) {
+        log.info("sending payload='{}' to no topic as kafka support is disabled", payload);
+    }
 }

--- a/song-server/src/main/java/bio/overture/song/server/service/analysis/AnalysisServiceSender.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/analysis/AnalysisServiceSender.java
@@ -1,12 +1,7 @@
 package bio.overture.song.server.service.analysis;
 
-import static bio.overture.song.core.model.enums.AnalysisActions.CREATE;
-import static bio.overture.song.core.model.enums.AnalysisActions.PUBLISH;
-import static bio.overture.song.core.model.enums.AnalysisActions.SUPPRESS;
-import static bio.overture.song.core.model.enums.AnalysisActions.UNPUBLISH;
-import static bio.overture.song.core.model.enums.AnalysisStates.PUBLISHED;
-import static bio.overture.song.core.model.enums.AnalysisStates.SUPPRESSED;
-import static bio.overture.song.core.model.enums.AnalysisStates.UNPUBLISHED;
+import static bio.overture.song.core.model.enums.AnalysisActions.*;
+import static bio.overture.song.core.model.enums.AnalysisStates.*;
 import static bio.overture.song.core.utils.JsonUtils.toJson;
 import static bio.overture.song.server.kafka.AnalysisMessage.createAnalysisMessage;
 
@@ -174,6 +169,6 @@ public class AnalysisServiceSender implements AnalysisService {
   private void sendAnalysisMessage(
       Analysis analysis, AnalysisStates analysisState, AnalysisActions action) {
     val message = createAnalysisMessage(action, analysis, songServerId);
-    sender.send(toJson(message));
+    sender.send(toJson(message), message.getAnalysisId());
   }
 }

--- a/song-server/src/test/java/bio/overture/song/server/service/AnalysisServiceSenderTest.java
+++ b/song-server/src/test/java/bio/overture/song/server/service/AnalysisServiceSenderTest.java
@@ -1,9 +1,6 @@
 package bio.overture.song.server.service;
 
-import static bio.overture.song.core.model.enums.AnalysisActions.CREATE;
-import static bio.overture.song.core.model.enums.AnalysisActions.PUBLISH;
-import static bio.overture.song.core.model.enums.AnalysisActions.SUPPRESS;
-import static bio.overture.song.core.model.enums.AnalysisActions.UNPUBLISH;
+import static bio.overture.song.core.model.enums.AnalysisActions.*;
 import static bio.overture.song.core.model.enums.AnalysisStates.UNPUBLISHED;
 import static bio.overture.song.core.utils.JsonUtils.toJson;
 import static bio.overture.song.core.utils.RandomGenerator.createRandomGenerator;
@@ -132,7 +129,7 @@ public class AnalysisServiceSenderTest {
 
     @Override
     @SneakyThrows
-    public void send(String actualAnalysisMessage) {
+    public void send(String actualAnalysisMessage, String _key) {
       assertEquals(expectedAnalysisMessage, actualAnalysisMessage);
     }
   }


### PR DESCRIPTION
When sending messages to a kafka topic with multiple partitions, we want to ensure that messages for each analysis end up in the same partition. This ensures that the consuming service can process them in chronological order. To accomplish this, we add the analysisId as the key to the kafka message.

To illustrate this scenario, imagine the `song_analysis` topic has 2 partitions to support 2 instances of **Maestro**. Now, a user creates a new analysis in **Song** which generates a kafka message with the `analysisState` = `UNPUBLISHED`. Then the user publishes that analysis, generating a kafka message with the `analysisState` = `PUBLISHED`. If those two messages end up in different partitions, it is possible that the `PUBLISHED` event is processed in advance of the `UNPUBLISHED` event, causing the analysis to be removed from the **Elasticsearch** index. If both messages are guaranteed to be placed in the same partition, then they will be consumed by the same instance of **Maestro**, processed in order, and this race condition won't occur.