### PR TITLE
publish snapshot images from custom branches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -331,4 +331,69 @@ pipeline {
             }
         }
     }
+
+    post {
+        fixed {
+            withCredentials([string(
+                credentialsId: 'OvertureSlackJenkinsWebhookURL',
+                variable: 'fixed_slackChannelURL'
+            )]) {
+                container('node') {
+                    script {
+                        if (env.BRANCH_NAME ==~ /(develop|main|master)/) {
+                            sh "curl \
+                                -X POST \
+                                -H 'Content-type: application/json' \
+                                --data '{ \
+                                    \"text\":\"Build Fixed: ${env.JOB_NAME} [Build ${env.BUILD_NUMBER}](${env.BUILD_URL}) \" \
+                                }' \
+                                ${fixed_slackChannelURL}"
+                        }
+                    }
+                }
+            }
+        }
+
+        success {
+            withCredentials([string(
+                credentialsId: 'OvertureSlackJenkinsWebhookURL',
+                variable: 'success_slackChannelURL'
+            )]) {
+                container('node') {
+                    script {
+                        if (env.BRANCH_NAME ==~ /(main|master)/) {
+                            sh "curl \
+                                -X POST \
+                                -H 'Content-type: application/json' \
+                                --data '{ \
+                                    \"text\":\"New Song published succesfully: v.${version} [Build ${env.BUILD_NUMBER}](${env.BUILD_URL}) \" \
+                                }' \
+                                ${success_slackChannelURL}"
+                        }
+                    }
+                }
+            }
+        }
+
+        unsuccessful {
+            withCredentials([string(
+                credentialsId: 'OvertureSlackJenkinsWebhookURL',
+                variable: 'failed_slackChannelURL'
+            )]) {
+                container('node') {
+                    script {
+                        if (env.BRANCH_NAME ==~ /(develop|main|master)/) {
+                            sh "curl \
+                                -X POST \
+                                -H 'Content-type: application/json' \
+                                --data '{ \
+                                    \"text\":\"Build Failed: ${env.JOB_NAME} [Build ${env.BUILD_NUMBER}](${env.BUILD_URL}) \" \
+                                }' \
+                                ${failed_slackChannelURL}"
+                        }
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
This abstracts the docker image build into a separate step —so that there’s only one reusable build, instead of multiple time consuming ones. Then, it relabels the same image into the different “tags”, and publishes those to `dockerhub` and `github packages`; but now that’s done in parallel streams, to save time.
And finally, it adds slack build + release notifications, as we should have those for all Overture pieces.

Bonuses:
- jenkins will fail the build if it gets stuck up to 30 mins (which shouldn’t ever happen).
- the jenkins logs will have timestamps now.