### PR TITLE
add Keycloak auth service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ package:
 # Start ego, score, and object-storage.
 start-deps: _setup package
 	@echo $(YELLOW)$(INFO_HEADER) "Starting dependencies: ego, score and object-storage" $(END)
-	@$(DC_UP_CMD) ego-api score-server object-storage dcc-id-server
+	@$(DC_UP_CMD) ego-api score-server object-storage
 
 # Start song-server and all dependencies. Affected by DEMO_MODE
 start-song-server: _setup package start-deps _setup-object-storage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   ego-api:
-    image: "overture/ego:3.4.0"
+    image: "overture/ego:5.3.0"
     environment:
       SERVER_PORT: 8080
       SPRING_DATASOURCE_URL: jdbc:postgresql://ego-postgres:5432/ego?stringtype=unspecified
@@ -9,7 +9,7 @@ services:
       SPRING_DATASOURCE_PASSWORD: password
       SPRING_FLYWAY_ENABLED: "true"
       SPRING_FLYWAY_LOCATIONS: "classpath:flyway/sql,classpath:db/migration"
-      SPRING_PROFILES: demo, auth
+      SPRING_PROFILES_ACTIVE: demo, auth
       JWT_DURATIONMS: 300000 # expire tokens in 5 min for local testing
     expose:
       - "8080"
@@ -43,7 +43,7 @@ services:
     ports:
       - "8085:9000"
   score-server:
-    image: overture/score-server:5.1.0
+    image: overture/score-server:5.10.0
     user: "$MY_UID:$MY_GID"
     environment:
       SPRING_PROFILES_ACTIVE: amazon,collaboratory,prod,secure,jwt
@@ -86,7 +86,7 @@ services:
       - "./docker/scratch/score-server-logs:/score-server/logs"
 
   score-client:
-    image: overture/score:5.0.0
+    image: overture/score:5.10.0
     environment:
       ACCESSTOKEN: f69b726d-d40f-4261-b105-1ec7e6bf04d5
       METADATA_URL: http://song-server:8080
@@ -151,6 +151,7 @@ services:
       AUTH_SERVER_CLIENTID: song
       AUTH_SERVER_TOKENNAME: apiKey
       AUTH_SERVER_CLIENTSECRET: songsecret
+      AUTH_SERVER_PROVIDER: ego
       AUTH_SERVER_SCOPE_STUDY_PREFIX: song.
       AUTH_SERVER_SCOPE_STUDY_SUFFIX: .WRITE
       AUTH_SERVER_SCOPE_SYSTEM: song.WRITE
@@ -165,15 +166,6 @@ services:
       SPRING_DATASOURCE_URL: jdbc:postgresql://song-db/song?stringtype=unspecified
       SPRING_FLYWAY_ENABLED: "true"
       SPRING_FLYWAY_LOCATIONS: "classpath:db/migration"
-      ID_USELOCAL: "false"
-      ID_FEDERATED_AUTH_BEARER_TOKEN:              f69b726d-d40f-4261-b105-1ec7e6bf04d5
-      ID_FEDERATED_URITEMPLATE_DONOR:              http://dcc-id-server:8080/donor/id?submittedProjectId={studyId}&submittedDonorId={submitterId}&create=true
-      ID_FEDERATED_URITEMPLATE_SPECIMEN:           http://dcc-id-server:8080/specimen/id?submittedProjectId={studyId}&submittedSpecimenId={submitterId}&create=true
-      ID_FEDERATED_URITEMPLATE_SAMPLE:             http://dcc-id-server:8080/sample/id?submittedProjectId={studyId}&submittedSampleId={submitterId}&create=true
-      ID_FEDERATED_URITEMPLATE_FILE:               http://dcc-id-server:8080/object/id?analysisId={analysisId}&fileName={fileName}
-      ID_FEDERATED_URITEMPLATE_ANALYSIS_EXISTENCE: http://dcc-id-server:8080/analysis/id?submittedAnalysisId={analysisId}&create=false
-      ID_FEDERATED_URITEMPLATE_ANALYSIS_GENERATE:  http://dcc-id-server:8080/analysis/unique
-      ID_FEDERATED_URITEMPLATE_ANALYSIS_SAVE:      http://dcc-id-server:8080/analysis/id?submittedAnalysisId={analysisId}&create=true
       JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,address=*:5006,server=y,suspend=n
     restart: always
     ports:
@@ -183,39 +175,9 @@ services:
       - song-db
       - ego-api
       - score-server
-      - dcc-id-server
     volumes:
       - "./docker/scratch/song-server-logs:/song-server/logs"
     user: song
-  dcc-id-db:
-    image: icgcdcc/dcc-id-db:3908f82
-    environment:
-      POSTGRES_DB: dcc_identifier
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
-  dcc-id-server:
-    image: icgcdcc/dcc-id-server:3908f82
-    environment:
-      AUTH_SERVER_URL: http://ego-api:8080/o/check_token/
-      AUTH_SERVER_CLIENTID: dcc-id
-      AUTH_SERVER_CLIENTSECRET: dccidsecret
-      AUTH_SERVER_PREFIX: id
-      AUTH_SERVER_SUFFIX: WRITE
-      AUTH_CONNECTION_MAXRETRIES: 5
-      AUTH_CONNECTION_INITIALBACKOFF: 15000
-      AUTH_CONNECTION_MULTIPLIER: 2.0
-      SPRING_DATASOURCE_URL: jdbc:postgresql://dcc-id-db/dcc_identifier
-      SPRING_DATASOURCE_USERNAME: postgres
-      SPRING_DATASOURCE_PASSWORD: password
-      SPRING_PROFILES_ACTIVE: secure
-    restart: always
-    depends_on:
-      - dcc-id-db
-      - ego-api
-    expose:
-      - "8080"
-    ports:
-      - "8086:8080"
 
 volumes:
     object-storage-data: {}

--- a/docker/ego-init/init.sql
+++ b/docker/ego-init/init.sql
@@ -295,7 +295,8 @@ ALTER TABLE public.userpermission OWNER TO postgres;
 --
 
 COPY public.egoapplication (name, clientid, clientsecret, redirecturi, description, status, id, type) FROM stdin;
-song-to-score	songToScore	songToScoreSecret	http://example.com	song-to-score	APPROVED	77f1ef78-7495-4b4a-982a-6b9532dc69fb	CLIENT
+song	song	songsecret	http://example.com	song-to-score	APPROVED	77f1ef78-7495-4b4a-982a-6b9532dc69fb	CLIENT
+score	score	scoresecret	http://example.com	score	APPROVED	8b573f1b-fbf8-413b-af5d-c17fd75aa00e	CLIENT
 \.
 
 
@@ -346,6 +347,7 @@ COPY public.flyway_schema_history (installed_rank, version, description, type, s
 
 COPY public.groupapplication (group_id, application_id) FROM stdin;
 f2885e96-f74e-4f7a-b935-fb48b18e761d	77f1ef78-7495-4b4a-982a-6b9532dc69fb
+f2885e96-f74e-4f7a-b935-fb48b18e761d	8b573f1b-fbf8-413b-af5d-c17fd75aa00e
 \.
 
 

--- a/song-server/src/main/java/bio/overture/song/server/config/KeycloakConfig.java
+++ b/song-server/src/main/java/bio/overture/song/server/config/KeycloakConfig.java
@@ -1,0 +1,47 @@
+package bio.overture.song.server.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Configuration
+@Getter
+public class KeycloakConfig {
+
+  @Value("${auth.server.clientID}")
+  private String uma_audience;
+
+  @Value("${auth.server.keycloak.host}")
+  private String host;
+
+  @Value("${auth.server.keycloak.realm}")
+  private String realm;
+
+  @Value("${auth.server.keycloak.enabled:false}")
+  private boolean enabled;
+
+  private static final String UMA_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:uma-ticket";
+  private static final String UMA_RESPONSE_MODE = "permissions";
+
+  public URI permissionUrl(){
+    return UriComponentsBuilder.fromHttpUrl(host)
+        .path("realms")
+        .path(realm)
+        .path("protocol/openid-connect/token")
+        .build()
+        .toUri();
+  }
+
+  public MultiValueMap<String, String> getUmaParams(){
+    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+    map.add("grant_type", UMA_GRANT_TYPE);
+    map.add("audience", uma_audience);
+    map.add("response_mode", UMA_RESPONSE_MODE);
+    return map;
+  }
+}

--- a/song-server/src/main/java/bio/overture/song/server/config/KeycloakConfig.java
+++ b/song-server/src/main/java/bio/overture/song/server/config/KeycloakConfig.java
@@ -30,9 +30,7 @@ public class KeycloakConfig {
 
   public URI permissionUrl(){
     return UriComponentsBuilder.fromHttpUrl(host)
-        .path("realms")
-        .path(realm)
-        .path("protocol/openid-connect/token")
+        .pathSegment("realms", realm, "protocol/openid-connect/token")
         .build()
         .toUri();
   }

--- a/song-server/src/main/java/bio/overture/song/server/config/KeycloakConfig.java
+++ b/song-server/src/main/java/bio/overture/song/server/config/KeycloakConfig.java
@@ -22,9 +22,6 @@ public class KeycloakConfig {
   @Value("${auth.server.keycloak.realm}")
   private String realm;
 
-  @Value("${auth.server.keycloak.enabled:false}")
-  private boolean enabled;
-
   private static final String UMA_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:uma-ticket";
   private static final String UMA_RESPONSE_MODE = "permissions";
 

--- a/song-server/src/main/java/bio/overture/song/server/config/SecurityConfig.java
+++ b/song-server/src/main/java/bio/overture/song/server/config/SecurityConfig.java
@@ -67,6 +67,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private String introspectionUri;
     private String clientId;
     private String clientSecret;
+    private String provider;
 
     private final ScopeConfig scope = new ScopeConfig();
 
@@ -74,6 +75,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     public SystemSecurity systemSecurity() {
       return SystemSecurity.builder()
           .systemScope(scope.getSystem())
+          .provider(provider)
           .build();
     }
 
@@ -95,6 +97,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .studyPrefix(scope.getStudy().getPrefix())
                 .studySuffix(scope.getStudy().getSuffix())
                 .systemScope(scope.getSystem())
+                .provider(provider)
                 .build();
     }
 

--- a/song-server/src/main/java/bio/overture/song/server/config/SecurityConfig.java
+++ b/song-server/src/main/java/bio/overture/song/server/config/SecurityConfig.java
@@ -72,7 +72,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Bean
     public SystemSecurity systemSecurity() {
-        return new SystemSecurity(scope.getSystem(), introspectionUri);
+      return SystemSecurity.builder()
+          .systemScope(scope.getSystem())
+          .build();
     }
 
     @Bean
@@ -88,12 +90,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     }
 
     @Bean
-    public StudySecurity studySecurity(@Autowired SystemSecurity systemSecurity) {
+    public StudySecurity studySecurity() {
         return StudySecurity.builder()
                 .studyPrefix(scope.getStudy().getPrefix())
                 .studySuffix(scope.getStudy().getSuffix())
                 .systemScope(scope.getSystem())
-                .introspectionUri(introspectionUri)
                 .build();
     }
 

--- a/song-server/src/main/java/bio/overture/song/server/config/SecurityConfig.java
+++ b/song-server/src/main/java/bio/overture/song/server/config/SecurityConfig.java
@@ -72,7 +72,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Bean
     public SystemSecurity systemSecurity() {
-        return new SystemSecurity(scope.getSystem());
+        return new SystemSecurity(scope.getSystem(), introspectionUri);
     }
 
     @Bean
@@ -93,6 +93,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .studyPrefix(scope.getStudy().getPrefix())
                 .studySuffix(scope.getStudy().getSuffix())
                 .systemScope(scope.getSystem())
+                .introspectionUri(introspectionUri)
                 .build();
     }
 

--- a/song-server/src/main/java/bio/overture/song/server/config/SecurityConfig.java
+++ b/song-server/src/main/java/bio/overture/song/server/config/SecurityConfig.java
@@ -68,6 +68,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private String clientId;
     private String clientSecret;
     private String provider;
+    private String tokenName;
 
     private final ScopeConfig scope = new ScopeConfig();
 
@@ -86,7 +87,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         // but OpaqueTokens are handled by the custom ApiKeyIntrospector
         AuthenticationManager jwt = new ProviderManager(new JwtAuthenticationProvider(jwtDecoder));
         AuthenticationManager opaqueToken =
-                new ProviderManager(new OpaqueTokenAuthenticationProvider(new ApiKeyIntrospector(introspectionUri, clientId, clientSecret)));
+                new ProviderManager(new OpaqueTokenAuthenticationProvider(new ApiKeyIntrospector(introspectionUri, clientId, clientSecret, tokenName)));
 
         return (request) -> useJwt(request) ? jwt : opaqueToken;
     }
@@ -103,7 +104,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Bean
     public OpaqueTokenIntrospector introspector() {
-        return new ApiKeyIntrospector(introspectionUri, clientId, clientSecret);
+        return new ApiKeyIntrospector(introspectionUri, clientId, clientSecret, tokenName);
     }
 
     @Override
@@ -163,7 +164,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             String token = authorizationHeaderValue.substring(7);
             try {
                 UUID.fromString(token);
-                // able to parse as UUID, so this token matches our EgoApiKey format
+                // able to parse as UUID, so this token matches our ApiKey format
                 return false;
             } catch (IllegalArgumentException e) {
                 // unable to parse as UUID, use our JWT resolvers

--- a/song-server/src/main/java/bio/overture/song/server/config/SecurityConfig.java
+++ b/song-server/src/main/java/bio/overture/song/server/config/SecurityConfig.java
@@ -16,7 +16,7 @@
  */
 package bio.overture.song.server.config;
 
-import bio.overture.song.server.security.EgoApiKeyIntrospector;
+import bio.overture.song.server.security.ApiKeyIntrospector;
 import bio.overture.song.server.security.StudySecurity;
 import bio.overture.song.server.security.SystemSecurity;
 import lombok.Getter;
@@ -83,10 +83,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     public AuthenticationManagerResolver<HttpServletRequest> tokenAuthenticationManagerResolver() {
 
         // Auth Managers for JWT and for ApiKeys. JWT uses the default auth provider,
-        // but OpaqueTokens are handled by the custom EgoApiKeyIntrospector
+        // but OpaqueTokens are handled by the custom ApiKeyIntrospector
         AuthenticationManager jwt = new ProviderManager(new JwtAuthenticationProvider(jwtDecoder));
         AuthenticationManager opaqueToken =
-                new ProviderManager(new OpaqueTokenAuthenticationProvider(new EgoApiKeyIntrospector(introspectionUri, clientId, clientSecret)));
+                new ProviderManager(new OpaqueTokenAuthenticationProvider(new ApiKeyIntrospector(introspectionUri, clientId, clientSecret)));
 
         return (request) -> useJwt(request) ? jwt : opaqueToken;
     }
@@ -103,7 +103,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Bean
     public OpaqueTokenIntrospector introspector() {
-        return new EgoApiKeyIntrospector(introspectionUri, clientId, clientSecret);
+        return new ApiKeyIntrospector(introspectionUri, clientId, clientSecret);
     }
 
     @Override

--- a/song-server/src/main/java/bio/overture/song/server/security/ApiKeyIntrospectResponse.java
+++ b/song-server/src/main/java/bio/overture/song/server/security/ApiKeyIntrospectResponse.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class EgoApiKeyIntrospectResponse {
+public class ApiKeyIntrospectResponse {
   private long exp;
   private String user_id;
   public List<String> scope;

--- a/song-server/src/main/java/bio/overture/song/server/security/ApiKeyIntrospector.java
+++ b/song-server/src/main/java/bio/overture/song/server/security/ApiKeyIntrospector.java
@@ -8,6 +8,7 @@ import lombok.val;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.GrantedAuthority;
@@ -17,6 +18,8 @@ import org.springframework.security.oauth2.server.resource.introspection.BadOpaq
 import org.springframework.security.oauth2.server.resource.introspection.OAuth2IntrospectionAuthenticatedPrincipal;
 import org.springframework.security.oauth2.server.resource.introspection.OAuth2IntrospectionException;
 import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -34,29 +37,34 @@ public class ApiKeyIntrospector implements OpaqueTokenIntrospector {
     private String introspectionUri;
     private String clientId;
     private String clientSecret;
+    private String tokenName;
 
     @Override
     public OAuth2AuthenticatedPrincipal introspect(String token) {
+
+            // Add token to body
+            MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+            formData.add(tokenName, token);
+
             // Add token to introspectionUri
             val uriWithToken =
-                    UriComponentsBuilder.fromHttpUrl(introspectionUri)
-                            .queryParam("apiKey", token)
-                            .build()
-                            .toUri();
+                UriComponentsBuilder.fromHttpUrl(introspectionUri)
+                    .build()
+                    .toUri();
 
             // Get response from Ego
             val template = new RestTemplate();
             template.setErrorHandler(new RestTemplateResponseErrorHandler());
             val response =
                     template.postForEntity(
-                            uriWithToken, new HttpEntity<Void>(null, getBasicAuthHeader()), JsonNode.class);
+                            uriWithToken, new HttpEntity<>(formData, getBasicAuthHeader()), JsonNode.class);
 
             // Ensure response was OK
             if ((response.getStatusCode() != HttpStatus.OK
                     && response.getStatusCode() != HttpStatus.MULTI_STATUS
                     && response.getStatusCode() != HttpStatus.UNAUTHORIZED)
                     || !response.hasBody()) {
-                throw new OAuth2IntrospectionException("Bad Response from Ego Server");
+                throw new OAuth2IntrospectionException("Bad Response from Auth Server");
             }
 
             val responseBody = response.getBody();
@@ -73,6 +81,7 @@ public class ApiKeyIntrospector implements OpaqueTokenIntrospector {
     private HttpHeaders getBasicAuthHeader() {
         val headers = new HttpHeaders();
         headers.setBasicAuth(clientId, clientSecret);
+        headers.set(HttpHeaders.CONTENT_TYPE, MediaType.MULTIPART_FORM_DATA_VALUE);
         return headers;
     }
 
@@ -86,10 +95,21 @@ public class ApiKeyIntrospector implements OpaqueTokenIntrospector {
                     "Check Token response is unauthorized but does not list the error. Rejecting token.");
             return false;
         }
-    /* TODO: joneubank 2022-06-10 this should be checking for expiry and active=true instead of just the presence of
-       an error field, but at the moment the Ego check_api_token endpoint either returns 401+error, or it is active
-       (Ego version 5.3.0)
-    */
+        if(response.has("exp") && response.get("exp").asLong() == 0){
+          log.debug("Token is expired. Rejecting token.");
+          return false;
+        }
+
+        if(response.has("revoked") && response.get("revoked").asBoolean() == true){
+          log.debug("Token is revoked. Rejecting token.");
+          return false;
+        }
+
+        if(response.has("valid") && response.get("valid").asBoolean() == false){
+          log.debug("Check Token response 'valid' field is false. Rejecting token.");
+          return false;
+        }
+
         return true;
     }
 

--- a/song-server/src/main/java/bio/overture/song/server/security/ApiKeyIntrospector.java
+++ b/song-server/src/main/java/bio/overture/song/server/security/ApiKeyIntrospector.java
@@ -29,7 +29,7 @@ import static org.springframework.http.HttpStatus.Series.SERVER_ERROR;
 
 @Slf4j
 @AllArgsConstructor
-public class EgoApiKeyIntrospector implements OpaqueTokenIntrospector {
+public class ApiKeyIntrospector implements OpaqueTokenIntrospector {
 
     private String introspectionUri;
     private String clientId;
@@ -94,7 +94,7 @@ public class EgoApiKeyIntrospector implements OpaqueTokenIntrospector {
     }
 
     private OAuth2AuthenticatedPrincipal convertResponseToPrincipal(JsonNode responseJson) {
-        val response = JsonUtils.convertValue(responseJson, EgoApiKeyIntrospectResponse.class);
+        val response = JsonUtils.convertValue(responseJson, ApiKeyIntrospectResponse.class);
 
         Collection<GrantedAuthority> authorities = new ArrayList();
         Map<String, Object> claims = new HashMap<>();

--- a/song-server/src/main/java/bio/overture/song/server/security/KeycloakAuthorizationService.java
+++ b/song-server/src/main/java/bio/overture/song/server/security/KeycloakAuthorizationService.java
@@ -1,0 +1,120 @@
+package bio.overture.song.server.security;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.oauth2.server.resource.introspection.BadOpaqueTokenException;
+import org.springframework.security.oauth2.server.resource.introspection.OAuth2IntrospectionException;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.Series.CLIENT_ERROR;
+import static org.springframework.http.HttpStatus.Series.SERVER_ERROR;
+
+@Slf4j
+@Builder
+public class KeycloakAuthorizationService {
+
+  private static final String UMA_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:uma-ticket";
+  private static final String UMA_AUDIENCE = "song";
+  private static final String UMA_RESPONSE_MODE = "permissions";
+
+  @NonNull private String introspectionUri;
+
+  public List<KeycloakPermission> fetchAuthorizationGrants(String accessToken){
+    // Add token to introspectionUri
+    val uriWithToken =
+        UriComponentsBuilder.fromHttpUrl(introspectionUri)
+            .build()
+            .toUri();
+
+    HttpEntity<MultiValueMap<String, String>> request =
+        new HttpEntity<>(getUmaParams(), getBearerAuthHeader(accessToken));
+
+    // Get response from Keycloak
+    val template = new RestTemplate();
+    template.setErrorHandler(new RestTemplateResponseErrorHandler());
+    val response =
+        template.postForEntity(
+            uriWithToken, request, KeycloakPermission[].class);
+
+    // Ensure response was OK
+    if ((response.getStatusCode() != HttpStatus.OK
+        && response.getStatusCode() != HttpStatus.MULTI_STATUS
+        && response.getStatusCode() != HttpStatus.UNAUTHORIZED)
+        || !response.hasBody()) {
+      throw new OAuth2IntrospectionException("Bad Response from Keycloak Server");
+    }
+
+    val isValid = validateIntrospectResponse(response.getStatusCode());
+    if (!isValid) {
+      throw new BadOpaqueTokenException("ApiKey is revoked or expired.");
+    }
+
+    return List.of(response.getBody());
+  }
+
+  private MultiValueMap<String, String> getUmaParams(){
+    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+    map.add("grant_type", UMA_GRANT_TYPE);
+    map.add("audience", UMA_AUDIENCE);
+    map.add("response_mode", UMA_RESPONSE_MODE);
+    return map;
+  }
+
+  private HttpHeaders getBearerAuthHeader(String token) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+    headers.setBearerAuth(token);
+    return headers;
+  }
+
+  private boolean validateIntrospectResponse(HttpStatus status) {
+    if (status != HttpStatus.OK && status != HttpStatus.MULTI_STATUS) {
+      log.debug(
+          "Check Token response is unauthorized but does not list the error. Rejecting token.");
+      return false;
+    }
+    return true;
+  }
+
+  private static class RestTemplateResponseErrorHandler
+      implements ResponseErrorHandler {
+
+    @Override
+    public boolean hasError(ClientHttpResponse httpResponse)
+        throws IOException {
+
+      return (
+          httpResponse.getStatusCode().series() == CLIENT_ERROR
+              || httpResponse.getStatusCode().series() == SERVER_ERROR);
+    }
+
+    @Override
+    public void handleError(ClientHttpResponse httpResponse)
+        throws IOException {
+
+      if (httpResponse.getStatusCode().series() == CLIENT_ERROR) {
+        // throw 401 HTTP error code
+        throw new BadCredentialsException(httpResponse.getStatusText());
+      } else {
+        // throw 500 HTTP error code
+        throw new OAuth2IntrospectionException(httpResponse.getStatusText());
+      }
+    }
+  }
+
+}

--- a/song-server/src/main/java/bio/overture/song/server/security/KeycloakPermission.java
+++ b/song-server/src/main/java/bio/overture/song/server/security/KeycloakPermission.java
@@ -1,0 +1,16 @@
+package bio.overture.song.server.security;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class KeycloakPermission {
+  private String rsid;
+  private String rsname;
+  private List<String> scopes;
+}

--- a/song-server/src/main/java/bio/overture/song/server/security/StudySecurity.java
+++ b/song-server/src/main/java/bio/overture/song/server/security/StudySecurity.java
@@ -16,16 +16,17 @@
  */
 package bio.overture.song.server.security;
 
+import static bio.overture.song.server.utils.Scopes.extractGrantedScopes;
 import static bio.overture.song.server.utils.Scopes.extractGrantedScopesFromRpt;
 
 import java.util.Set;
-import lombok.Builder;
-import lombok.NonNull;
-import lombok.Value;
+
+import bio.overture.song.server.service.auth.KeycloakAuthorizationService;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
-import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
 @Slf4j
@@ -36,22 +37,32 @@ public class StudySecurity {
   @NonNull private final String studyPrefix;
   @NonNull private final String studySuffix;
   @NonNull private final String systemScope;
-  @NonNull private final String introspectionUri;
 
   @Autowired
-  public KeycloakAuthorizationService keycloakAuthorizationService() {
-    return KeycloakAuthorizationService.builder()
-        .introspectionUri(introspectionUri)
-        .build();
-  }
+  private KeycloakAuthorizationService keycloakAuthorizationService;
 
   public boolean authorize(@NonNull Authentication authentication, @NonNull final String studyId) {
     log.info("Checking study-level authorization for studyId {}", studyId);
 
-    val authGrants = keycloakAuthorizationService()
-        .fetchAuthorizationGrants(((JwtAuthenticationToken) authentication).getToken().getTokenValue());
+    Set<String> grantedScopes;
 
-    val grantedScopes = extractGrantedScopesFromRpt(authGrants);
+    if(keycloakAuthorizationService.isEnabled()) {
+      String token = "";
+      if(authentication instanceof JwtAuthenticationToken){
+        token = ((JwtAuthenticationToken) authentication).getToken().getTokenValue();
+      } else if(authentication instanceof BearerTokenAuthentication){
+        token = ((BearerTokenAuthentication) authentication).getToken().getTokenValue();
+      }
+      // retrieve permission from Keycloak server
+      val authGrants = keycloakAuthorizationService
+          .fetchAuthorizationGrants(token);
+
+      grantedScopes = extractGrantedScopesFromRpt(authGrants);
+    } else{
+      // extract scopes from authentication token
+      grantedScopes = extractGrantedScopes(authentication);
+    }
+
     return verifyOneOfStudyScope(grantedScopes, studyId);
   }
 

--- a/song-server/src/main/java/bio/overture/song/server/security/SystemSecurity.java
+++ b/song-server/src/main/java/bio/overture/song/server/security/SystemSecurity.java
@@ -17,23 +17,38 @@
 package bio.overture.song.server.security;
 
 import static bio.overture.song.server.utils.Scopes.extractGrantedScopes;
+import static bio.overture.song.server.utils.Scopes.extractGrantedScopesFromRpt;
 
 import java.util.Set;
 import lombok.NonNull;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
 @Slf4j
 @Value
 public class SystemSecurity {
 
   @NonNull private final String systemScope;
+  @NonNull private final String introspectionUri;
+
+  @Autowired
+  public KeycloakAuthorizationService keycloakAuthorizationService() {
+    return KeycloakAuthorizationService.builder()
+        .introspectionUri(introspectionUri)
+        .build();
+  }
 
   public boolean authorize(@NonNull Authentication authentication) {
     log.debug("Checking system-level authorization");
-    val grantedScopes = extractGrantedScopes(authentication);
+
+    val authGrants = keycloakAuthorizationService()
+        .fetchAuthorizationGrants(((JwtAuthenticationToken) authentication).getToken().getTokenValue());
+
+    val grantedScopes = extractGrantedScopesFromRpt(authGrants);
     return verifyOneOfSystemScope(grantedScopes);
   }
 

--- a/song-server/src/main/java/bio/overture/song/server/service/auth/KeycloakAuthorizationService.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/auth/KeycloakAuthorizationService.java
@@ -33,8 +33,8 @@ public class KeycloakAuthorizationService {
   }
 
   public List<KeycloakPermission> fetchAuthorizationGrants(String accessToken){
-    // Add token to introspectionUri
-    val uriWithToken = keycloakConfig.permissionUrl();
+
+    val serviceUrl = keycloakConfig.permissionUrl();
 
     HttpEntity<MultiValueMap<String, String>> request =
         new HttpEntity<>(keycloakConfig.getUmaParams(), getBearerAuthHeader(accessToken));
@@ -47,7 +47,7 @@ public class KeycloakAuthorizationService {
       template.setErrorHandler(new RestTemplateResponseErrorHandler());
       response =
           template.postForEntity(
-              uriWithToken, request, KeycloakPermission[].class);
+              serviceUrl, request, KeycloakPermission[].class);
     } catch (ResourceAccessException e) {
       log.error(
           "KeycloakAuthorizationService - error cause:"
@@ -71,11 +71,6 @@ public class KeycloakAuthorizationService {
     }
 
     return List.of(response.getBody());
-  }
-
-  public boolean isEnabled(){
-    log.info("checking if Keycloak is enabled: "+ keycloakConfig.isEnabled());
-    return keycloakConfig.isEnabled();
   }
 
   private HttpHeaders getBearerAuthHeader(String token) {

--- a/song-server/src/main/java/bio/overture/song/server/utils/Scopes.java
+++ b/song-server/src/main/java/bio/overture/song/server/utils/Scopes.java
@@ -2,12 +2,12 @@ package bio.overture.song.server.utils;
 
 import static lombok.AccessLevel.PRIVATE;
 
+import bio.overture.song.server.security.KeycloakPermission;
 import com.nimbusds.jose.shaded.json.JSONArray;
 import com.nimbusds.jose.shaded.json.JSONObject;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+
+import java.util.*;
+
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -30,6 +30,22 @@ public class Scopes {
     } else if (authentication instanceof BearerTokenAuthentication) {
       grantedScopes = getApiKeyScopes((BearerTokenAuthentication) authentication);
     }
+    return grantedScopes;
+  }
+
+  public static Set<String> extractGrantedScopesFromRpt(List<KeycloakPermission> permissionList) {
+    Set<String> grantedScopes = new HashSet();
+
+    permissionList
+        .stream()
+        .filter(perm -> perm.getScopes() != null)
+        .forEach(permission -> {
+          permission.getScopes().stream().forEach(scope -> {
+            val fullScope = permission.getRsname() + "." + scope;
+            grantedScopes.add(fullScope);
+          });
+        });
+
     return grantedScopes;
   }
 

--- a/song-server/src/main/resources/application.yml
+++ b/song-server/src/main/resources/application.yml
@@ -211,6 +211,7 @@ auth:
   server:
     # check API Key endpoint
     introspectionUri: http://localhost:8081/o/check_api_key
+    tokenName: apiKey
     # Define a valid auth provider: ego or keycloak
     provider: ego
     # Keycloak config

--- a/song-server/src/main/resources/application.yml
+++ b/song-server/src/main/resources/application.yml
@@ -201,10 +201,13 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          public-key-location: http://localhost:8081/oauth/token/public_key
+          # EGO public key
+#          public-key-location: http://localhost:8081/oauth/token/public_key
+          # Keycloak JWT
+          jwk-set-uri: http://localhost/realms/myrealm/protocol/openid-connect/certs
 auth:
   server:
-    introspectionUri: http://localhost:8081/o/check_api_key
+    introspectionUri: http://localhost/realms/myrealm/protocol/openid-connect/token
     clientID: id
     clientSecret: secret
     scope:

--- a/song-server/src/main/resources/application.yml
+++ b/song-server/src/main/resources/application.yml
@@ -24,6 +24,8 @@ song:
 server:
   version: 1.0
   port: 8080
+  # fix issue IllegalArgumentException: Request header is too large. default 8KB
+  max-http-header-size: 10KB
 
 score:
   # Require both upload and download scopes
@@ -204,13 +206,15 @@ spring:
           # EGO public key
           public-key-location: http://localhost:8081/oauth/token/public_key
           # Keycloak JWK
-          #jwk-set-uri: http://localhost/realms/virusseq/protocol/openid-connect/certs
+          #jwk-set-uri: http://localhost/realms/myrealm/protocol/openid-connect/certs
 auth:
   server:
+    # check API Key endpoint
     introspectionUri: http://localhost:8081/o/check_api_key
-    # Keycloak
+    # Define a valid auth provider: ego or keycloak
+    provider: ego
+    # Keycloak config
     keycloak:
-      enabled: false
       host: http://localhost
       realm: "myrealm"
 

--- a/song-server/src/main/resources/application.yml
+++ b/song-server/src/main/resources/application.yml
@@ -202,12 +202,18 @@ spring:
       resourceserver:
         jwt:
           # EGO public key
-#          public-key-location: http://localhost:8081/oauth/token/public_key
-          # Keycloak JWT
-          jwk-set-uri: http://localhost/realms/myrealm/protocol/openid-connect/certs
+          public-key-location: http://localhost:8081/oauth/token/public_key
+          # Keycloak JWK
+          #jwk-set-uri: http://localhost/realms/virusseq/protocol/openid-connect/certs
 auth:
   server:
-    introspectionUri: http://localhost/realms/myrealm/protocol/openid-connect/token
+    introspectionUri: http://localhost:8081/o/check_api_key
+    # Keycloak
+    keycloak:
+      enabled: false
+      host: http://localhost
+      realm: "myrealm"
+
     clientID: id
     clientSecret: secret
     scope:

--- a/song-server/src/test/java/bio/overture/song/server/security/TestScopeStrategy.java
+++ b/song-server/src/test/java/bio/overture/song/server/security/TestScopeStrategy.java
@@ -32,7 +32,7 @@ public class TestScopeStrategy {
   @Autowired
   private KeycloakAuthorizationService keycloakAuthorizationService;
 
-  private final SystemSecurity SYSTEM_SECURITY = new SystemSecurity("song.READ", keycloakAuthorizationService);
+  private final SystemSecurity SYSTEM_SECURITY = SystemSecurity.builder().systemScope("song.READ").build();
   private static final StudySecurity STUDY_SECURITY1 =
       StudySecurity.builder()
           .studyPrefix("song.")

--- a/song-server/src/test/java/bio/overture/song/server/security/TestScopeStrategy.java
+++ b/song-server/src/test/java/bio/overture/song/server/security/TestScopeStrategy.java
@@ -20,12 +20,19 @@ package bio.overture.song.server.security;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import bio.overture.song.server.service.auth.KeycloakAuthorizationService;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.testcontainers.shaded.com.google.common.collect.Sets;
 
+@SpringBootTest
 public class TestScopeStrategy {
 
-  private static final SystemSecurity SYSTEM_SECURITY = new SystemSecurity("song.READ");
+  @Autowired
+  private KeycloakAuthorizationService keycloakAuthorizationService;
+
+  private final SystemSecurity SYSTEM_SECURITY = new SystemSecurity("song.READ", keycloakAuthorizationService);
   private static final StudySecurity STUDY_SECURITY1 =
       StudySecurity.builder()
           .studyPrefix("song.")
@@ -91,7 +98,7 @@ public class TestScopeStrategy {
     assertFalse(testSystemVerify("SONG.READ"));
   }
 
-  private static boolean testSystemVerify(String... grantedScopes) {
+  private boolean testSystemVerify(String... grantedScopes) {
     return SYSTEM_SECURITY.verifyOneOfSystemScope(Sets.newHashSet(grantedScopes));
   }
 

--- a/song-server/src/test/java/bio/overture/song/server/security/TestStudySecurity.java
+++ b/song-server/src/test/java/bio/overture/song/server/security/TestStudySecurity.java
@@ -58,7 +58,8 @@ public class TestStudySecurity {
         val prefix = "PROGRAMDATA-";
         val suffix = ".READ";
         val scope = "DCC.READ";
-        val studySecurity = new StudySecurity(prefix, suffix, scope);
+        val introspectorUri = "http://localhost/realms/myrealm/protocol/openid-connect/token";
+        val studySecurity = new StudySecurity(prefix, suffix, scope, introspectorUri);
         val authentication = new AccessTokenConverterWithExpiry().extractAuthentication(map);
 
         assertEquals(expected, studySecurity.authorize(authentication, TEST_STUDY));

--- a/song-server/src/test/java/bio/overture/song/server/security/TestStudySecurity.java
+++ b/song-server/src/test/java/bio/overture/song/server/security/TestStudySecurity.java
@@ -1,18 +1,22 @@
 package bio.overture.song.server.security;
 
 import bio.overture.song.server.oauth.AccessTokenConverterWithExpiry;
+import bio.overture.song.server.service.auth.KeycloakAuthorizationService;
 import lombok.val;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 
+@SpringBootTest
 public class TestStudySecurity {
     String TEST_STUDY = "TEST-CA";
+
+  @Autowired
+  private KeycloakAuthorizationService keycloakAuthorizationService;
 
     @Test
     public void testValidStudyScopeOK() {
@@ -58,8 +62,7 @@ public class TestStudySecurity {
         val prefix = "PROGRAMDATA-";
         val suffix = ".READ";
         val scope = "DCC.READ";
-        val introspectorUri = "http://localhost/realms/myrealm/protocol/openid-connect/token";
-        val studySecurity = new StudySecurity(prefix, suffix, scope, introspectorUri);
+        val studySecurity = new StudySecurity(prefix, suffix, scope, keycloakAuthorizationService);
         val authentication = new AccessTokenConverterWithExpiry().extractAuthentication(map);
 
         assertEquals(expected, studySecurity.authorize(authentication, TEST_STUDY));

--- a/song-server/src/test/java/bio/overture/song/server/security/TestStudySecurity.java
+++ b/song-server/src/test/java/bio/overture/song/server/security/TestStudySecurity.java
@@ -62,7 +62,11 @@ public class TestStudySecurity {
         val prefix = "PROGRAMDATA-";
         val suffix = ".READ";
         val scope = "DCC.READ";
-        val studySecurity = new StudySecurity(prefix, suffix, scope, keycloakAuthorizationService);
+        val studySecurity = StudySecurity.builder()
+            .studyPrefix(prefix)
+            .studySuffix(suffix)
+            .systemScope(scope)
+            .build();
         val authentication = new AccessTokenConverterWithExpiry().extractAuthentication(map);
 
         assertEquals(expected, studySecurity.authorize(authentication, TEST_STUDY));

--- a/song-server/src/test/java/bio/overture/song/server/security/TestSystemSecurity.java
+++ b/song-server/src/test/java/bio/overture/song/server/security/TestSystemSecurity.java
@@ -59,7 +59,10 @@ public class TestSystemSecurity {
 
     public void test_authorize(Map<String, ?> map, boolean expected) {
         val scope = "DCC.READ";
-        val systemSecurity = new SystemSecurity(scope, keycloakAuthorizationService);
+        val provider = "ego";
+        val systemSecurity = SystemSecurity.builder()
+            .systemScope(scope)
+            .build();
         val authentication = new AccessTokenConverterWithExpiry().extractAuthentication(map);
 
         assertEquals(expected, systemSecurity.authorize(authentication));

--- a/song-server/src/test/java/bio/overture/song/server/security/TestSystemSecurity.java
+++ b/song-server/src/test/java/bio/overture/song/server/security/TestSystemSecurity.java
@@ -1,17 +1,21 @@
 package bio.overture.song.server.security;
 
 import bio.overture.song.server.oauth.AccessTokenConverterWithExpiry;
+import bio.overture.song.server.service.auth.KeycloakAuthorizationService;
 import lombok.val;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 
+@SpringBootTest
 public class TestSystemSecurity {
+
+  @Autowired
+  private KeycloakAuthorizationService keycloakAuthorizationService;
 
     @Test
     public void testValidStudyScopeFails() {
@@ -55,7 +59,7 @@ public class TestSystemSecurity {
 
     public void test_authorize(Map<String, ?> map, boolean expected) {
         val scope = "DCC.READ";
-        val systemSecurity = new SystemSecurity(scope);
+        val systemSecurity = new SystemSecurity(scope, keycloakAuthorizationService);
         val authentication = new AccessTokenConverterWithExpiry().extractAuthentication(map);
 
         assertEquals(expected, systemSecurity.authorize(authentication));


### PR DESCRIPTION
- Added Keycloak as an alternative auth service 
- Added new env variables:
  -  spring.security.oauth2.resourceserver.jwk-set-url: (Keycloak JWK URL)
  - auth.server.provider: (Choose `ego` or `keycloak` as an auth server)
  - auth.server.keycloak.host: (Keycloak hostname)
  - auth.server.keycloak.realm: (Keycloak realm)