### PR TITLE
Refactor ICGC Bucket Names to SCORe in Docker-Compose and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,18 +90,18 @@ _ping_song_db:
 
 
 _setup-object-storage: 
-	@echo $(YELLOW)$(INFO_HEADER) "Setting up bucket oicr.icgc.test and heliograph" $(END)
-	@if  $(DOCKER_COMPOSE_CMD) run aws-cli --endpoint-url http://object-storage:9000 s3 ls s3://oicr.icgc.test ; then \
+	@echo $(YELLOW)$(INFO_HEADER) "Setting up bucket score.data and heliograph" $(END)
+	@if  $(DOCKER_COMPOSE_CMD) run aws-cli --endpoint-url http://object-storage:9000 s3 ls s3://score.data ; then \
 		echo $(YELLOW)$(INFO_HEADER) "Bucket already exists. Skipping creation..." $(END); \
 	else \
-		$(DOCKER_COMPOSE_CMD) run aws-cli --endpoint-url http://object-storage:9000 s3 mb s3://oicr.icgc.test; \
+		$(DOCKER_COMPOSE_CMD) run aws-cli --endpoint-url http://object-storage:9000 s3 mb s3://score.data; \
 	fi
-	@$(DOCKER_COMPOSE_CMD) run aws-cli --endpoint-url http://object-storage:9000 s3 cp /score-data/heliograph s3://oicr.icgc.test/data/heliograph
+	@$(DOCKER_COMPOSE_CMD) run aws-cli --endpoint-url http://object-storage:9000 s3 cp /score-data/heliograph s3://score.data/data/heliograph
 
 _destroy-object-storage:
-	@echo $(YELLOW)$(INFO_HEADER) "Removing bucket oicr.icgc.test" $(END)
-	@if  $(DOCKER_COMPOSE_CMD) run aws-cli --endpoint-url http://object-storage:9000 s3 ls s3://oicr.icgc.test ; then \
-		$(DOCKER_COMPOSE_CMD) run aws-cli --endpoint-url http://object-storage:9000 s3 rb s3://oicr.icgc.test --force; \
+	@echo $(YELLOW)$(INFO_HEADER) "Removing bucket score.data" $(END)
+	@if  $(DOCKER_COMPOSE_CMD) run aws-cli --endpoint-url http://object-storage:9000 s3 ls s3://score.data ; then \
+		$(DOCKER_COMPOSE_CMD) run aws-cli --endpoint-url http://object-storage:9000 s3 rb s3://score.data --force; \
 	else \
 		echo $(YELLOW)$(INFO_HEADER) "Bucket does not exist. Skipping..." $(END); \
 	fi

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -35,8 +35,8 @@ services:
       AUTH_SERVER_UPLOADSCOPE: song.upload
       SERVER_URL: http://localhost:8087
       SERVER_PORT: 8087
-      BUCKET_NAME_OBJECT: oicr.icgc.test
-      BUCKET_NAME_STATE: oicr.icgc.test
+      BUCKET_NAME_OBJECT: score.data
+      BUCKET_NAME_STATE: score.test
       COLLABORATORY_DATA_DIRECTORY: data
       OBJECT_SENTINEL: heliograph
       METADATA_URL: "http://localhost:8080"

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       SERVER_URL: http://localhost:8087
       SERVER_PORT: 8087
       BUCKET_NAME_OBJECT: score.data
-      BUCKET_NAME_STATE: score.test
+      BUCKET_NAME_STATE: score.data
       COLLABORATORY_DATA_DIRECTORY: data
       OBJECT_SENTINEL: heliograph
       METADATA_URL: "http://localhost:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       SERVER_PORT: 8080
       OBJECT_SENTINEL: heliograph
       BUCKET_NAME_OBJECT: score.data
-      BUCKET_NAME_STATE: score.test
+      BUCKET_NAME_STATE: score.data
       COLLABORATORY_DATA_DIRECTORY: data
       METADATA_URL: http://song-server:8080
       S3_ENDPOINT:  http://object-storage:9000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,8 +54,8 @@ services:
       SPRING_PROFILES_ACTIVE: amazon,collaboratory,prod,secure
       SERVER_PORT: 8080
       OBJECT_SENTINEL: heliograph
-      BUCKET_NAME_OBJECT: oicr.icgc.test
-      BUCKET_NAME_STATE: oicr.icgc.test
+      BUCKET_NAME_OBJECT: score.data
+      BUCKET_NAME_STATE: score.test
       COLLABORATORY_DATA_DIRECTORY: data
       METADATA_URL: http://song-server:8080
       S3_ENDPOINT:  http://object-storage:9000
@@ -129,7 +129,7 @@ services:
       AWS_SECRET_ACCESS_KEY: minio123
       AWS_DEFAULT_REGION: us-east-1
     volumes:
-      - "./docker/object-storage-init/data/oicr.icgc.test/data:/score-data:ro"
+      - "./docker/object-storage-init/data/score.data/data:/score-data:ro"
 
   song-client:
     build:


### PR DESCRIPTION
This PR renames the default bucket names in the Docker-Compose setup from oicr.icgc.test to score.data and score.state to align with the SCORe project. It also updates the Makefile to reference the new bucket names. All instances of oicr.icgc.test in the relevant sections have been replaced with score.data to remove outdated ICGC references and standardize the configuration. #848 #846 