### PR TITLE
Dynamic Schema Support for Analysis-Specific File Types and Adding data migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,9 +57,12 @@
             <url>https://jcenter.bintray.com/</url>
         </repository>
         <repository>
-            <id>spring-releases</id>
+            <id>lib-releases</id>
             <name>Spring Releases</name>
             <url>https://repo.spring.io/libs-release</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
     </repositories>
 

--- a/song-server/src/main/resources/db/migration/V1_20__update_legacy_analysis.sql
+++ b/song-server/src/main/resources/db/migration/V1_20__update_legacy_analysis.sql
@@ -1,8 +1,8 @@
 UPDATE public.analysis_schema
-SET  "schema"='{"type":"object","required":["experiment"],"properties":{"experiment":{"type":"object","required":["matchedNormalSampleSubmitterId","variantCallingTool"],"properties":{"variantCallingTool":{"type":"string"},"matchedNormalSampleSubmitterId":{"type":"string"},"fileTypes":{"enum":["VCF","BAM","OTHER_CUSTOM_TYPE"],"type":"string"}}}}}'::jsonb
-where name = 'variantCall';
+SET "schema"='{"type":"object","required":["experiment"],"properties":{"experiment":{"type":"object","required":["matchedNormalSampleSubmitterId","variantCallingTool"],"properties":{"fileTypes":{"oneOf":[{"$ref":"classpath:/schemas/analysis/analysisBase.json#/definitions/file/fileType"},{"type":"string"}]},"variantCallingTool":{"type":"string"},"matchedNormalSampleSubmitterId":{"type":"string"}}}}}'::jsonb
+WHERE "name"='variantCall';
 
 
 UPDATE public.analysis_schema
-SET  "schema"='{"type":"object","required":["experiment"],"properties":{"experiment":{"type":"object","required":["libraryStrategy"],"properties":{"aligned":{"type":["boolean","null"]},"pairedEnd":{"type":["boolean","null"]},"insertSize":{"type":["integer","null"]},"alignmentTool":{"type":["string","null"]},"libraryStrategy":{"enum":["WGS","WXS","RNA-Seq","ChIP-Seq","miRNA-Seq","Bisulfite-Seq","Validation","Amplicon","Other"],"type":"string"},"referenceGenome":{"type":["string","null"]},"fileTypes":{"enum":["FASTQ","BAM","CRAM"],"type":"string"}}}}}'::jsonb
-where name = 'sequencingRead';
+SET "schema"='{"type":"object","required":["experiment"],"properties":{"experiment":{"type":"object","required":["libraryStrategy"],"properties":{"aligned":{"type":["boolean","null"]},"fileTypes":{"oneOf":[{"$ref":"classpath:/schemas/analysis/analysisBase.json#/definitions/file/fileType"},{"type":"string"}]},"pairedEnd":{"type":["boolean","null"]},"insertSize":{"type":["integer","null"]},"alignmentTool":{"type":["string","null"]},"libraryStrategy":{"enum":["WGS","WXS","RNA-Seq","ChIP-Seq","miRNA-Seq","Bisulfite-Seq","Validation","Amplicon","Other"],"type":"string"},"referenceGenome":{"type":["string","null"]}}}}}'::jsonb
+WHERE "name"='sequencingRead';

--- a/song-server/src/main/resources/db/migration/V1_20__update_legacy_analysis.sql
+++ b/song-server/src/main/resources/db/migration/V1_20__update_legacy_analysis.sql
@@ -1,0 +1,8 @@
+UPDATE public.analysis_schema
+SET  "schema"='{"type":"object","required":["experiment"],"properties":{"experiment":{"type":"object","required":["matchedNormalSampleSubmitterId","variantCallingTool"],"properties":{"variantCallingTool":{"type":"string"},"matchedNormalSampleSubmitterId":{"type":"string"},"fileTypes":{"enum":["VCF","BAM","OTHER_CUSTOM_TYPE"],"type":"string"}}}}}'::jsonb
+where name = 'variantCall';
+
+
+UPDATE public.analysis_schema
+SET  "schema"='{"type":"object","required":["experiment"],"properties":{"experiment":{"type":"object","required":["libraryStrategy"],"properties":{"aligned":{"type":["boolean","null"]},"pairedEnd":{"type":["boolean","null"]},"insertSize":{"type":["integer","null"]},"alignmentTool":{"type":["string","null"]},"libraryStrategy":{"enum":["WGS","WXS","RNA-Seq","ChIP-Seq","miRNA-Seq","Bisulfite-Seq","Validation","Amplicon","Other"],"type":"string"},"referenceGenome":{"type":["string","null"]},"fileTypes":{"enum":["FASTQ","BAM","CRAM"],"type":"string"}}}}}'::jsonb
+where name = 'sequencingRead';

--- a/song-server/src/main/resources/schemas/analysis/analysisBase.json
+++ b/song-server/src/main/resources/schemas/analysis/analysisBase.json
@@ -18,22 +18,7 @@
     },
     "file": {
       "fileType": {
-        "type": "string",
-        "enum": [
-          "FASTA",
-          "FAI",
-          "FASTQ",
-          "BAM",
-          "BAI",
-          "VCF",
-          "TBI",
-          "IDX",
-          "XML",
-          "TGZ",
-          "CRAM",
-          "CRAI",
-          "TXT"
-        ]
+        "type": "string"
       },
       "fileData": {
         "type": "object",

--- a/song-server/src/main/resources/schemas/analysis/analysisTypeRegistration.json
+++ b/song-server/src/main/resources/schemas/analysis/analysisTypeRegistration.json
@@ -10,7 +10,23 @@
             "const": "object"
         },
         "definitions" : {
-          "type" : "object"
+          "type" : "object",
+            "properties": {
+                "file": {
+                    "type": "object",
+                    "properties": {
+                        "fileType": {
+                            "oneOf": [
+                                { "$ref": "classpath:/schemas/analysis/analysisBase.json#/definitions/file/fileType"},
+                                {
+                                    "type": "string",
+                                    "enum": ["VCF", "BAM", "OTHER_CUSTOM_TYPE"]
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
         },
         "properties" : {
             "type": "object",

--- a/song-server/src/main/resources/schemas/analysis/analysisTypeRegistration.json
+++ b/song-server/src/main/resources/schemas/analysis/analysisTypeRegistration.json
@@ -14,15 +14,16 @@
             "properties": {
                 "file": {
                     "type": "object",
-                    "properties": {
-                        "fileType": {
-                            "oneOf": [
-                                { "$ref": "classpath:/schemas/analysis/analysisBase.json#/definitions/file/fileType"},
-                                {
-                                    "type": "string",
-                                    "enum": ["VCF", "BAM", "OTHER_CUSTOM_TYPE"]
-                                }
-                            ]
+                    "properties":
+                                 {
+                            "fileType": {
+                                "oneOf": [
+                                    { "$ref": "classpath:/schemas/analysis/analysisBase.json#/definitions/file/fileType" },
+                                    {
+                                        "type": "string"
+                                    }
+                                ]
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This PR introduces changes to the base schema and dynamic schemas to support the flexible definition of file types for different analysis types. Key modifications include:

Base Schema Updates:

 fileType is now defined as its own separate definition.

 The only validation on fileType is that it must be a string.

 file.fileType now references the fileType definition.

 fileType remains a required property for file.

Analysis Type Registration Schema:

Allows dynamic schemas to define additional restrictions on file.fileType.
If the user provides a fileType definition during analysis type registration, it will merge with the base schema definition, allowing for analysis-specific file type validation./

This update also includes a data migration to refine the list of valid file types associated with the legacy analysis types (sequencing-experiment and variant-calling) that were pre-loaded into the Song database.

Summary of Changes:

Specific File Type Lists:
The list of valid file types for sequencing-experiment and variant-calling analysis types has been updated to be specific to these analysis types, replacing the previous implementation where a broad list of file types was allowed.
This change ensures that only relevant file types can be used with each analysis type, enhancing data validation and integrity.