### PR TITLE
Added FileTypes to  ListAnalysisTypes Response.

### DIFF
--- a/song-server/src/main/java/bio/overture/song/server/service/AnalysisTypeService.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/AnalysisTypeService.java
@@ -272,7 +272,7 @@ public class AnalysisTypeService {
             .fileTypes(fileTypes)
             .build();
 
-    log.debug("Creating analysisSchema with file types: {}  " + fileTypes);
+    log.info("file types " + fileTypes);
     analysisSchemaRepository.save(analysisSchema);
     val version =
         analysisSchemaRepository.countAllByNameAndIdLessThanEqual(
@@ -318,11 +318,14 @@ public class AnalysisTypeService {
 
   private AnalysisType convertToAnalysisType(
       AnalysisSchema analysisSchema, boolean hideSchema, boolean unrenderedOnly) {
+    AnalysisTypeOptions options = new AnalysisTypeOptions();
+    options.setFileTypes(analysisSchema.getFileTypes());
     return AnalysisType.builder()
         .name(analysisSchema.getName())
         .version(analysisSchema.getVersion())
         .createdAt(analysisSchema.getCreatedAt())
         .schema(resolveSchemaJsonView(analysisSchema.getSchema(), unrenderedOnly, hideSchema))
+        .options(options)
         .build();
   }
 

--- a/song-server/src/main/java/bio/overture/song/server/service/AnalysisTypeService.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/AnalysisTypeService.java
@@ -272,7 +272,7 @@ public class AnalysisTypeService {
             .fileTypes(fileTypes)
             .build();
 
-    log.info("file types " + fileTypes);
+    log.debug("Creating analysisSchema with file types: {}  " + fileTypes);
     analysisSchemaRepository.save(analysisSchema);
     val version =
         analysisSchemaRepository.countAllByNameAndIdLessThanEqual(


### PR DESCRIPTION
This PR modifies the **AnalysisTypeService** to include **fileTypes** in the **AnalysisType** response by introducing an **AnalysisTypeOptions** object. Previously, the convertToAnalysisType method only mapped the name, version, createdAt, and schema of the AnalysisSchema. With this update, the list of **fileTypes** defined for each analysis type is now also included in the **options** field of the response.

This change is important as the **ListAnalysisType** endpoint will now return file type information for the various analysis types, providing more flexibility and clarity when working with custom analysis types.