### PR TITLE
Enable Version-Based File Type Validation for Analysis Submission

### DIFF
--- a/song-server/src/main/java/bio/overture/song/server/repository/AnalysisSchemaRepository.java
+++ b/song-server/src/main/java/bio/overture/song/server/repository/AnalysisSchemaRepository.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 
 public interface AnalysisSchemaRepository
     extends JpaRepository<AnalysisSchema, Integer>, JpaSpecificationExecutor<AnalysisSchema> {
@@ -32,5 +33,5 @@ public interface AnalysisSchemaRepository
 
   Optional<AnalysisSchema> findByNameAndVersion(String name, Integer version);
 
-  List<AnalysisSchema> findByName(String name);
+  List<AnalysisSchema> findAllByName(String name);
 }

--- a/song-server/src/main/java/bio/overture/song/server/service/AnalysisTypeService.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/AnalysisTypeService.java
@@ -269,6 +269,24 @@ public class AnalysisTypeService {
     if (options != null && CollectionUtils.isNotEmpty(options.getFileTypes())) {
       fileTypes = options.getFileTypes();
     }
+
+    // checking if file types is empty
+    // if the version is new version of the schema , we are checking the previous version allowed file types
+    // if it is new then it is empty
+    if(fileTypes.isEmpty()){
+      List<AnalysisSchema> analysisSchemaList = analysisSchemaRepository.findAllByName(analysisTypeName);
+
+      if(!analysisSchemaList.isEmpty()){
+        Optional<AnalysisSchema> latestSchemaOptional =  analysisSchemaList.stream()
+                .filter(schema -> schema.getVersion() != null)
+                .max(Comparator.comparingInt(AnalysisSchema::getVersion));
+
+        if(latestSchemaOptional.isPresent()){
+          fileTypes = latestSchemaOptional.get().getFileTypes();
+        }
+      }
+    }
+
     val analysisSchema =
         AnalysisSchema.builder()
             .name(analysisTypeName)

--- a/song-server/src/main/java/bio/overture/song/server/service/AnalysisTypeService.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/AnalysisTypeService.java
@@ -99,6 +99,10 @@ public class AnalysisTypeService {
     return analysisTypeRegistrationSchema;
   }
 
+  public List<AnalysisSchema> getAllAnalysisSchemas(String name) {
+    return analysisSchemaRepository.findAllByName(name);
+  }
+
   public AnalysisType getAnalysisType(
       @NonNull String name, @Nullable Integer version, boolean unrenderedOnly) {
     val resolvedVersion = isNull(version) ? getLatestVersionNumber(name) : version;

--- a/song-server/src/main/java/bio/overture/song/server/service/ValidationService.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/ValidationService.java
@@ -225,12 +225,3 @@ public class ValidationService {
     }
   }
 }
-
-
-
-
-
-
-
-
-

--- a/song-server/src/main/java/bio/overture/song/server/service/ValidationService.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/ValidationService.java
@@ -98,31 +98,11 @@ public class ValidationService {
       if (analysisType.getOptions() != null && analysisType.getOptions().getFileTypes() != null) {
         fileTypes = analysisType.getOptions().getFileTypes();
       }
-      // Only use the file type rules from the corresponding schema version
-      Integer schemaVersion = analysisType.getVersion();
-      if (Objects.isNull(schemaVersion)) {
-        // No version specified, use the latest schema version
-        if (fileTypes.isEmpty()) {
-          // Reuse file types from the latest schema version
-          List<AnalysisSchema> previousSchemas = analysisTypeService.getAllAnalysisSchemas(analysisType.getName());
-          List<String> previousFileTypes = previousSchemas.stream()
-              .filter(schema -> schema.getFileTypes() != null)
-              .flatMap(schema -> schema.getFileTypes().stream())
-              .distinct()
-              .collect(Collectors.toList());
-          if (!previousFileTypes.isEmpty()) {
-            validateFileType(previousFileTypes, payload);
-          }
-        } else {
-          // File types are defined in the current schema
-          validateFileType(fileTypes, payload);
-        }
-      } else {
-        // Specific schema version is defined, use its file types
-        if (!fileTypes.isEmpty()) {
-          validateFileType(fileTypes, payload);
-        }
+
+      if (!fileTypes.isEmpty()) {
+        validateFileType(fileTypes, payload);
       }
+
       val schema = buildSchema(analysisType.getSchema());
       validateWithSchema(schema, payload);
     } catch (ValidationException e) {


### PR DESCRIPTION
This PR implements changes to support file type validation based on the analysis version provided during submission. Key updates include:

**File Type Validation by Version:**

- When submitting an analysis, the file types will now be validated according to the version specified in the payload.

- If no version is specified, the latest version is used by default.

**Handling File Types Across Versions:**

- If no file types are provided for a particular version, the system retrieves file types from previous versions.

- If it is the first version and no file types are specified, all file types are allowed (null value or empty array).

- If file types are explicitly provided, those will be used regardless of the version.

- An empty `fileTypes` array is treated the same as a null value, meaning all file types are allowed.

**Repository Changes:**
In AnalysisSchemaRepository, updated method signatures:

- [x] Changed findByName to findAllByName to fetch all schemas for a name.

**Validation Logic:**

Updated in `ValidationService` to fetch and validate file types from the correct version:

- if no `options.fileType` is provided, it looks for the latest schema version and re-use the file types
-  if a` options.fileType `is an empty array, set no value for file types, indicates any file type is allowed
- if a `options.fileType` is an array with values, set this as the value for file types

These changes ensure that the file types are consistently validated based on the correct version, improving flexibility for versioned analysis types.