### PR TITLE
JWT decoder config

### DIFF
--- a/song-server/src/main/java/bio/overture/song/server/config/JwtDecoderConfig.java
+++ b/song-server/src/main/java/bio/overture/song/server/config/JwtDecoderConfig.java
@@ -1,0 +1,79 @@
+package bio.overture.song.server.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.Resource;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+
+@Slf4j
+@Getter
+@Setter
+@Profile("secure")
+@Configuration
+@ConfigurationProperties("spring.security.oauth2.resourceserver.jwt")
+public class JwtDecoderConfig {
+
+  private Resource publicKeyLocation;
+
+  private String jwkSetUri;
+
+  @Bean
+  @Primary
+  public JwtDecoder jwtDecoder() {
+    try {
+      if (isPublicKeyConfigured()) {
+        return NimbusJwtDecoder.withPublicKey(loadRsaPublicKey()).build();
+      } else if (isJwkSetUriConfigured()) {
+        return NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build();
+      } else {
+        throw new IllegalStateException("Neither public-key-location nor jwk-set-uri is configured.");
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to configure JwtDecoder", e);
+    }
+  }
+
+  private boolean isPublicKeyConfigured() {
+    return publicKeyLocation != null && publicKeyLocation.exists();
+  }
+
+  private boolean isJwkSetUriConfigured() {
+    return jwkSetUri != null && !jwkSetUri.isBlank();
+  }
+
+  private RSAPublicKey loadRsaPublicKey() throws Exception {
+    try (InputStream input = publicKeyLocation.getInputStream()) {
+      String key = new String(input.readAllBytes(), StandardCharsets.UTF_8)
+          .replace("-----BEGIN PUBLIC KEY-----", "")
+          .replace("-----END PUBLIC KEY-----", "")
+          .replaceAll("\\s+", "");
+      byte[] decoded = Base64.getDecoder().decode(key);
+
+      X509EncodedKeySpec keySpec = new X509EncodedKeySpec(decoded);
+      KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+      PublicKey publicKey = keyFactory.generatePublic(keySpec);
+
+      if (!(publicKey instanceof RSAPublicKey)) {
+        throw new IllegalArgumentException("The provided key is not an RSA public key");
+      }
+
+      return (RSAPublicKey) publicKey;
+
+    }
+  }
+}

--- a/song-server/src/main/resources/application.yml
+++ b/song-server/src/main/resources/application.yml
@@ -154,7 +154,9 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          # Uncomment the public-key-location below for Ego configurations
+          # Choose only one of these properties.
+          # Use 'public-key-location' when integrating with EGO
+          # For modern applications using OAuth2 or OpenID Connect providers like Keycloak, 'jwk-set-uri' is recommended
           # public-key-location: http://localhost:8081/oauth/token/public_key  
           jwk-set-uri: http://localhost/realms/myrealm/protocol/openid-connect/certs  
 


### PR DESCRIPTION
# Pull Request

## Description

This PR refactors the `JwtDecoder` configuration to provide a custom bean that dynamically selects between using a public key location or a JWK Set URL.

It considers two environment variables:

- The `SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_PUBLIC_KEY_LOCATION` variable points to a public key file. This option is used if both environment variables are set.

- The `SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI` variable points to a JWK Set URL.



Fixes the Issue:
- Application fails to decode a JWT due to a conflict in the default configuration, where two resources are being configured for JWT decoding. 

## Type of change

Please choose only the relevant options and remove the others.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [X] Tested locally, set an environment variable to override the default configuration, making sure a JWT token is decoded successfully. 

## Checklist:

You do not need to fullfill all requirements of this checklist, select all that apply:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
