### PR TITLE
#884: Improve endpoint error outputs with detailed messages

### DIFF
--- a/song-server/src/main/java/bio/overture/song/server/controller/SubmitController.java
+++ b/song-server/src/main/java/bio/overture/song/server/controller/SubmitController.java
@@ -25,10 +25,15 @@ import bio.overture.song.core.model.SubmitResponse;
 import bio.overture.song.server.service.SubmitService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import java.util.HashMap;
+import java.util.Map;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.joda.time.LocalDateTime;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
@@ -47,11 +52,24 @@ public class SubmitController {
       value = "/{studyId}",
       consumes = {APPLICATION_JSON_VALUE, APPLICATION_JSON_UTF8_VALUE})
   @PreAuthorize("@studySecurity.authorize(authentication, #studyId)")
-  public SubmitResponse submit(
+  public ResponseEntity<?> submit(
       @RequestHeader(value = AUTHORIZATION, required = false) final String accessToken,
       @PathVariable("studyId") String studyId,
       @RequestParam(value = "allowDuplicates", defaultValue = "false") boolean allowDuplicates,
       @RequestBody @Valid String json_payload) {
-    return submitService.submit(studyId, json_payload, allowDuplicates);
+    try {
+      SubmitResponse response = submitService.submit(studyId, json_payload, allowDuplicates);
+      return ResponseEntity.ok(response);
+    } catch (Exception e) {
+      log.error("Exception occurred {}", e.getMessage());
+
+      Map<String, Object> error = new HashMap<>();
+      error.put("error", "Internal Server Error");
+      error.put("message", e.getMessage());
+      error.put("status", 500);
+      error.put("timestamp", LocalDateTime.now().toString());
+
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+    }
   }
 }

--- a/song-server/src/main/java/bio/overture/song/server/controller/SubmitController.java
+++ b/song-server/src/main/java/bio/overture/song/server/controller/SubmitController.java
@@ -25,15 +25,10 @@ import bio.overture.song.core.model.SubmitResponse;
 import bio.overture.song.server.service.SubmitService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import java.util.HashMap;
-import java.util.Map;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.joda.time.LocalDateTime;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
@@ -52,24 +47,11 @@ public class SubmitController {
       value = "/{studyId}",
       consumes = {APPLICATION_JSON_VALUE, APPLICATION_JSON_UTF8_VALUE})
   @PreAuthorize("@studySecurity.authorize(authentication, #studyId)")
-  public ResponseEntity<?> submit(
+  public SubmitResponse submit(
       @RequestHeader(value = AUTHORIZATION, required = false) final String accessToken,
       @PathVariable("studyId") String studyId,
       @RequestParam(value = "allowDuplicates", defaultValue = "false") boolean allowDuplicates,
       @RequestBody @Valid String json_payload) {
-    try {
-      SubmitResponse response = submitService.submit(studyId, json_payload, allowDuplicates);
-      return ResponseEntity.ok(response);
-    } catch (Exception e) {
-      log.error("Exception occurred {}", e.getMessage());
-
-      Map<String, Object> error = new HashMap<>();
-      error.put("error", "Internal Server Error");
-      error.put("message", e.getMessage());
-      error.put("status", 500);
-      error.put("timestamp", LocalDateTime.now().toString());
-
-      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
-    }
+    return submitService.submit(studyId, json_payload, allowDuplicates);
   }
 }

--- a/song-server/src/main/java/bio/overture/song/server/service/SubmitService.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/SubmitService.java
@@ -89,7 +89,10 @@ public class SubmitService {
     try{
       analysis = analysisService.create(studyId, payload);
     } catch (Exception e){
-      throw new RuntimeException("unable to create Analysis {}"+ e.getMessage());
+      throw buildServerException(
+              getClass(),
+              UNKNOWN_ERROR,
+              "Unable to create Analysis. "+ e.getMessage());
     }
     return SubmitResponse.builder().analysisId(analysis.getAnalysisId()).status(OK).build();
   }

--- a/song-server/src/main/java/bio/overture/song/server/service/SubmitService.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/SubmitService.java
@@ -27,8 +27,11 @@ import static bio.overture.song.server.model.enums.ModelAttributeNames.NAME;
 import static bio.overture.song.server.model.enums.ModelAttributeNames.STUDY_ID;
 import static java.util.Objects.isNull;
 
+import bio.overture.song.core.exceptions.ServerException;
+import bio.overture.song.core.exceptions.SongError;
 import bio.overture.song.core.model.AnalysisTypeId;
 import bio.overture.song.core.model.SubmitResponse;
+import bio.overture.song.server.model.analysis.Analysis;
 import bio.overture.song.server.model.dto.Payload;
 import bio.overture.song.server.service.analysis.AnalysisService;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -81,7 +84,13 @@ public class SubmitService {
     }
 
     // Create the analysis
-    val analysis = analysisService.create(studyId, payload);
+    Analysis analysis;
+
+    try{
+      analysis = analysisService.create(studyId, payload);
+    } catch (Exception e){
+      throw new RuntimeException("unable to create Analysis {}"+ e.getMessage());
+    }
     return SubmitResponse.builder().analysisId(analysis.getAnalysisId()).status(OK).build();
   }
 


### PR DESCRIPTION
## Description

This PR improves the error response outputs for the Song submit and validate metadata endpoints. Previously, when an error occurred (such as invalid JSON or missing required fields), the API returned a generic 500 error with no useful details, making it difficult for users to debug submission issues.

**With this update:**

- Detailed and meaningful error messages are returned in the response body.
- HTTP status codes now reflect the type of error (e.g., 400 Bad Request for validation errors).
- Structured error responses include status, message, and relevant error details.
- Fixes #884

**Type of change**

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] First Create a StudyId using CreateStudy Endpoint and then by using [/submit/{studyId}/Submit] endpoint fill in the required details and the studyId which was created earlier.