### PR TITLE
#885: Remove requirement of experiment from analysisTypeRegistration.json

### DIFF
--- a/song-server/src/main/resources/schemas/analysis/analysisTypeRegistration.json
+++ b/song-server/src/main/resources/schemas/analysis/analysisTypeRegistration.json
@@ -14,7 +14,6 @@
         },
         "properties" : {
             "type": "object",
-            "required": ["experiment"],
             "additionalProperties": true,
             "properties": {
                 "studyId" : {
@@ -45,9 +44,6 @@
             "uniqueItems": true,
             "items": {
                 "type": "string"
-            },
-            "contains": {
-                "const": "experiment"
             }
         }
     },


### PR DESCRIPTION
## Description

Description:
Summary of Request: Remove the experiment field requirement from the analysisTypeRegistration.json schema. The decision on whether this field is required will now be delegated to the dynamic schema associated with each analysis type.
Summary of Changes:
* Removed experiment from the required array in analysisTypeRegistration.json.
* Updated validation logic (if applicable) to allow omission of experiment unless specified in the dynamic schema.
* Reviewed existing dynamic schemas to confirm they explicitly include experiment where needed.
* Added or updated test cases to verify the new behavior.
Related Issue: #885

## Type of change

Please choose only the relevant options and remove the others.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
