### PR TITLE
#890: Add option to allow_duplicates to Song Client Submit command

### DIFF
--- a/docs/02-Usage/00-submitting-metadata.md
+++ b/docs/02-Usage/00-submitting-metadata.md
@@ -88,6 +88,11 @@ Use the song-client `submit` command:
 docker exec song-client sh -c "sing submit -f /output/example-payload.json"
 ```
 
+To allow duplicate files, use the `-ad` option:
+```bash
+docker exec song-client sh -c "sing submit -f /output/example-payload.json -ad"
+```
+
 Successful submission returns an `analysisId`:
 
 ```json

--- a/docs/02-Usage/10-client-reference.md
+++ b/docs/02-Usage/10-client-reference.md
@@ -63,6 +63,11 @@ Commands and options supported by the Song client.
 
 - **Usage:** `song-client submit [OPTIONS]`
 
+    | Option                      | Description                                         |
+    |-----------------------------|-----------------------------------------------------|
+    | `-f`, `--file`              | File name and directory for the payload             |
+    | `-ad`, `--allow-duplicates` | Allows duplicate files identified by their MD5 hash |
+
     :::info
     For detailed information, see our [documentation on submitting data with Song](https://docs.overture.bio/docs/core-software/Song/Usage/submitting-metadata).
     :::

--- a/song-client/src/main/java/bio/overture/song/client/command/SubmitCommand.java
+++ b/song-client/src/main/java/bio/overture/song/client/command/SubmitCommand.java
@@ -38,6 +38,11 @@ public class SubmitCommand extends Command {
       required = true)
   private String fileName;
 
+  @Parameter(
+      names = {"-d", "--allow-duplicates"},
+      required = false)
+  private Boolean allowDuplicates = false;
+
   @NonNull private CustomRestClientConfig clientConfig;
   @NonNull private SongApi songApi;
 
@@ -52,7 +57,7 @@ public class SubmitCommand extends Command {
     }
 
     val json = readFileContent(filePath);
-    val submitResponse = songApi.submit(clientConfig.getStudyId(), json);
+    val submitResponse = songApi.submit(clientConfig.getStudyId(), json, allowDuplicates);
     prettyOutput(submitResponse);
   }
 }

--- a/song-client/src/main/java/bio/overture/song/client/command/SubmitCommand.java
+++ b/song-client/src/main/java/bio/overture/song/client/command/SubmitCommand.java
@@ -39,7 +39,7 @@ public class SubmitCommand extends Command {
   private String fileName;
 
   @Parameter(
-      names = {"-d", "--allow-duplicates"},
+      names = {"-ad", "--allow-duplicates"},
       required = false)
   private Boolean allowDuplicates = false;
 

--- a/song-client/src/test/java/bio/overture/song/client/HappyPathClientMainTest.java
+++ b/song-client/src/test/java/bio/overture/song/client/HappyPathClientMainTest.java
@@ -250,10 +250,11 @@ public class HappyPathClientMainTest extends AbstractClientMainTest {
   public void testSubmit() {
     val file = tmp.newFile();
     Files.write(file.toPath(), DUMMY_PAYLOAD.toString().getBytes());
+    val allowDuplicates = false;
 
     val expectedSubmitResponse =
         SubmitResponse.builder().analysisId(DUMMY_ANALYSIS_ID).status("ok").build();
-    when(songApi.submit(DUMMY_STUDY_ID, DUMMY_PAYLOAD.toString()))
+    when(songApi.submit(DUMMY_STUDY_ID, DUMMY_PAYLOAD.toString(), allowDuplicates))
         .thenReturn(expectedSubmitResponse);
     assertOutputJson(objectToTree(expectedSubmitResponse), "submit", "-f", file.getAbsolutePath());
     assertOutputJson(

--- a/song-java-sdk/src/main/java/bio/overture/song/sdk/SongApi.java
+++ b/song-java-sdk/src/main/java/bio/overture/song/sdk/SongApi.java
@@ -48,8 +48,9 @@ public class SongApi {
   }
 
   /** Submit an payload to the song server. */
-  public SubmitResponse submit(@NonNull String studyId, @NonNull String json) {
-    val url = endpoint.submit(studyId);
+  public SubmitResponse submit(
+      @NonNull String studyId, @NonNull String json, boolean allowDuplicates) {
+    val url = endpoint.submit(studyId, allowDuplicates);
     return restClient.post(url, json, SubmitResponse.class).getBody();
   }
 

--- a/song-java-sdk/src/main/java/bio/overture/song/sdk/web/Endpoint.java
+++ b/song-java-sdk/src/main/java/bio/overture/song/sdk/web/Endpoint.java
@@ -36,8 +36,8 @@ public class Endpoint {
     this.serverUrl = "";
   }
 
-  public String submit(@NonNull String studyId) {
-    return format("%s/submit/%s", serverUrl, studyId);
+  public String submit(@NonNull String studyId, boolean allowDuplicates) {
+    return format("%s/submit/%s?allowDuplicates=%s", serverUrl, studyId, allowDuplicates);
   }
 
   public String getAnalysisFiles(@NonNull String studyId, @NonNull String analysisId) {


### PR DESCRIPTION
## Summary
By default, **SONG** prevents submitting duplicate files based on their MD5 hash.
This PR adds an option in the **Song-client** to enable submitting duplicate files in the submit command.
You can use the optional flag `-ad` or `--allow-duplicates` in the submit command to allow duplicates.

## Issues
- #890 

## Readiness Checklist

- [X] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [X] **Formatting**
  - Code follows the project style guide
  - Autmated code formatters (ie. Prettier) have been run
- [X] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [X] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [X] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
