### PR TITLE
Refactor - Standardize Authorization requirements for all controllers

### DIFF
--- a/song-server/src/main/java/bio/overture/song/server/config/SecurityConfig.java
+++ b/song-server/src/main/java/bio/overture/song/server/config/SecurityConfig.java
@@ -34,6 +34,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationManagerResolver;
 import org.springframework.security.authentication.ProviderManager;
@@ -109,19 +110,24 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     http.authorizeRequests()
         .antMatchers("/isAlive")
         .permitAll()
-        .antMatchers("/studies/**")
-        .permitAll()
-        .antMatchers("/upload/**")
-        .permitAll()
         .antMatchers("/entities/**")
         .permitAll()
         .antMatchers("/export/**")
         .permitAll()
-        .antMatchers("/schemas/**")
+        .antMatchers(HttpMethod.GET, "/schemas/**") // AKA. AnalysisType
         .permitAll()
-        .antMatchers(swaggerConfig.getAlternateSwaggerUrl())
+        .antMatchers(
+            HttpMethod.GET,
+            "/studies/**") // This covers StudyController, FileController, and AnalysisController
         .permitAll()
-        .antMatchers("/swagger**", "/swagger-resources/**", "/v2/api**", "/webjars/**")
+        .antMatchers("/upload/**")
+        .permitAll()
+        .antMatchers(
+            swaggerConfig.getAlternateSwaggerUrl(),
+            "/swagger**",
+            "/swagger-resources/**",
+            "/v2/api**",
+            "/webjars/**")
         .permitAll()
         .and()
         .authorizeRequests()

--- a/song-server/src/main/java/bio/overture/song/server/config/SwaggerConfig.java
+++ b/song-server/src/main/java/bio/overture/song/server/config/SwaggerConfig.java
@@ -19,13 +19,17 @@ package bio.overture.song.server.config;
 
 import static springfox.documentation.builders.RequestHandlerSelectors.basePackage;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.*;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.paths.RelativePathProvider;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger.web.UiConfiguration;
@@ -64,7 +68,9 @@ public class SwaggerConfig {
               public String getApplicationBasePath() {
                 return basePath;
               }
-            });
+            })
+        .securitySchemes(securitySchemes())
+        .securityContexts(Collections.singletonList(securityContext()));
   }
 
   @Bean
@@ -90,5 +96,22 @@ public class SwaggerConfig {
                 + "of the raw data with regards to publication and access")
         .version(serverVersion)
         .build();
+  }
+
+  private static ArrayList<? extends SecurityScheme> securitySchemes() {
+    ArrayList<SecurityScheme> securitySchemes = new ArrayList<>();
+    securitySchemes.add(new ApiKey("Bearer", "Authorization", "header"));
+    return securitySchemes;
+  }
+
+  private SecurityContext securityContext() {
+    return SecurityContext.builder().securityReferences(defaultAuth()).build();
+  }
+
+  private List<SecurityReference> defaultAuth() {
+    AuthorizationScope authorizationScope = new AuthorizationScope("global", "");
+    AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+    authorizationScopes[0] = authorizationScope;
+    return Collections.singletonList(new SecurityReference("Bearer", authorizationScopes));
   }
 }

--- a/song-server/src/main/java/bio/overture/song/server/controller/AnalysisController.java
+++ b/song-server/src/main/java/bio/overture/song/server/controller/AnalysisController.java
@@ -19,7 +19,6 @@ package bio.overture.song.server.controller;
 import static bio.overture.song.core.utils.Separators.COMMA;
 import static bio.overture.song.server.repository.search.IdSearchRequest.createIdSearchRequest;
 import static java.lang.String.format;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -94,7 +93,6 @@ public class AnalysisController {
       value = "/{analysisId}",
       consumes = {APPLICATION_JSON_VALUE, APPLICATION_JSON_UTF8_VALUE})
   public void updateAnalysis(
-      @RequestHeader(value = AUTHORIZATION, required = false) final String accessToken,
       @PathVariable("studyId") String studyId,
       @PathVariable("analysisId") String analysisId,
       @RequestBody JsonNode updateAnalysisRequest) {
@@ -109,7 +107,6 @@ public class AnalysisController {
       value = "/{analysisId}",
       consumes = {APPLICATION_JSON_VALUE, APPLICATION_JSON_UTF8_VALUE})
   public void patchUpdateAnalysis(
-      @RequestHeader(value = AUTHORIZATION, required = false) final String accessToken,
       @PathVariable("studyId") String studyId,
       @PathVariable("analysisId") String analysisId,
       @RequestBody JsonNode patchUpdateAnalysisRequest) {
@@ -125,7 +122,6 @@ public class AnalysisController {
   @SneakyThrows
   @PreAuthorize("@studySecurity.authorize(authentication, #studyId)")
   public GenericMessage publishAnalysis(
-      @RequestHeader(value = AUTHORIZATION, required = false) final String accessToken,
       @PathVariable("studyId") String studyId,
       @PathVariable("id") String id,
       @ApiParam(value = "Ignores files that have an undefined MD5 checksum when publishing")
@@ -142,10 +138,8 @@ public class AnalysisController {
   @SneakyThrows
   @PreAuthorize("@studySecurity.authorize(authentication, #studyId)")
   public GenericMessage unpublishAnalysis(
-      @RequestHeader(value = AUTHORIZATION, required = false) final String accessToken,
-      @PathVariable("studyId") String studyId,
-      @PathVariable("id") String id) {
-    val analysis = analysisService.unpublish(studyId, id);
+      @PathVariable("studyId") String studyId, @PathVariable("id") String id) {
+    analysisService.unpublish(studyId, id);
     return new GenericMessage(format("AnalysisId " + id + " successfully unpublished"));
   }
 
@@ -158,10 +152,8 @@ public class AnalysisController {
   @SneakyThrows
   @PreAuthorize("@studySecurity.authorize(authentication, #studyId)")
   public GenericMessage suppressAnalysis(
-      @RequestHeader(value = AUTHORIZATION, required = false) final String accessToken,
-      @PathVariable("studyId") String studyId,
-      @PathVariable("id") String id) {
-    val analysis = analysisService.suppress(studyId, id);
+      @PathVariable("studyId") String studyId, @PathVariable("id") String id) {
+    analysisService.suppress(studyId, id);
     return new GenericMessage(format("AnalysisId " + id + " was suppressed"));
   }
 

--- a/song-server/src/main/java/bio/overture/song/server/controller/FileController.java
+++ b/song-server/src/main/java/bio/overture/song/server/controller/FileController.java
@@ -16,8 +16,6 @@
  */
 package bio.overture.song.server.controller;
 
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-
 import bio.overture.song.core.model.FileUpdateRequest;
 import bio.overture.song.core.model.FileUpdateResponse;
 import bio.overture.song.server.model.entity.FileEntity;
@@ -31,15 +29,7 @@ import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -69,7 +59,6 @@ public class FileController {
   @PreAuthorize("@studySecurity.authorize(authentication, #studyId)")
   @Transactional
   public FileUpdateResponse update(
-      @RequestHeader(value = AUTHORIZATION, required = false) final String accessToken,
       @PathVariable("studyId") String studyId,
       @PathVariable("id") String id,
       @ApiParam(value = "File data to update", required = true) @RequestBody
@@ -83,7 +72,6 @@ public class FileController {
   @PreAuthorize("@studySecurity.authorize(authentication, #studyId)")
   @Transactional
   public String delete(
-      @RequestHeader(value = AUTHORIZATION, required = false) final String accessToken,
       @PathVariable("studyId") String studyId,
       @PathVariable("ids") @ApiParam(value = "Comma separated list of fileIds", required = true)
           List<String> ids) {

--- a/song-server/src/main/java/bio/overture/song/server/controller/StudyController.java
+++ b/song-server/src/main/java/bio/overture/song/server/controller/StudyController.java
@@ -18,7 +18,6 @@ package bio.overture.song.server.controller;
 
 import static bio.overture.song.core.exceptions.ServerErrors.STUDY_ID_MISMATCH;
 import static bio.overture.song.core.exceptions.ServerException.checkServer;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -61,9 +60,7 @@ public class StudyController {
   @PreAuthorize("@studySecurity.authorize(authentication, #studyId)")
   @ResponseBody
   public GenericMessage saveStudy(
-      @PathVariable("studyId") String studyId,
-      @RequestHeader(value = AUTHORIZATION, required = false) final String accessToken,
-      @RequestBody Study study) {
+      @PathVariable("studyId") String studyId, @RequestBody Study study) {
     checkServer(
         studyId.equals(study.getStudyId()),
         getClass(),

--- a/song-server/src/main/java/bio/overture/song/server/controller/SubmitController.java
+++ b/song-server/src/main/java/bio/overture/song/server/controller/SubmitController.java
@@ -17,7 +17,6 @@
 
 package bio.overture.song.server.controller;
 
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -48,7 +47,6 @@ public class SubmitController {
       consumes = {APPLICATION_JSON_VALUE, APPLICATION_JSON_UTF8_VALUE})
   @PreAuthorize("@studySecurity.authorize(authentication, #studyId)")
   public SubmitResponse submit(
-      @RequestHeader(value = AUTHORIZATION, required = false) final String accessToken,
       @PathVariable("studyId") String studyId,
       @RequestParam(value = "allowDuplicates", defaultValue = "false") boolean allowDuplicates,
       @RequestBody @Valid String json_payload) {

--- a/song-server/src/main/java/bio/overture/song/server/controller/analysisType/AnalysisTypeController.java
+++ b/song-server/src/main/java/bio/overture/song/server/controller/analysisType/AnalysisTypeController.java
@@ -21,7 +21,6 @@ import static bio.overture.song.core.utils.JsonUtils.toPrettyJson;
 import static bio.overture.song.server.controller.analysisType.AnalysisTypePageableResolver.DEFAULT_LIMIT;
 import static bio.overture.song.server.controller.analysisType.AnalysisTypePageableResolver.DEFAULT_OFFSET;
 import static bio.overture.song.server.model.enums.ModelAttributeNames.*;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -92,9 +91,7 @@ public class AnalysisTypeController {
   @PreAuthorize("@systemSecurity.authorize(authentication)")
   @PostMapping(consumes = {APPLICATION_JSON_VALUE, APPLICATION_JSON_UTF8_VALUE})
   @ApiOperation(value = "RegisterAnalysisType", notes = "Registers an analysisType schema")
-  public @ResponseBody AnalysisType register(
-      @RequestHeader(value = AUTHORIZATION, required = false) final String accessToken,
-      @RequestBody RegisterAnalysisTypeRequest request) {
+  public @ResponseBody AnalysisType register(@RequestBody RegisterAnalysisTypeRequest request) {
     val options = request.getOptions() != null ? request.getOptions() : new AnalysisTypeOptions();
     return analysisTypeService.register(request.getName(), options, request.getSchema());
   }

--- a/song-server/src/main/java/bio/overture/song/server/service/analysis/AnalysisServiceSender.java
+++ b/song-server/src/main/java/bio/overture/song/server/service/analysis/AnalysisServiceSender.java
@@ -12,7 +12,6 @@ import bio.overture.song.server.model.analysis.Analysis;
 import bio.overture.song.server.model.dto.Payload;
 import bio.overture.song.server.model.entity.FileEntity;
 import bio.overture.song.server.repository.search.IdSearchRequest;
-import bio.overture.song.server.service.FileService;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Collection;
 import java.util.List;
@@ -34,18 +33,15 @@ public class AnalysisServiceSender implements AnalysisService {
   private final String songServerId;
   private final Sender sender;
   private final AnalysisService internalAnalysisService;
-  private final FileService fileService;
 
   @Autowired
   public AnalysisServiceSender(
       @Value("${song.id}") @NonNull String songServerId,
       @NonNull Sender sender,
-      @NonNull AnalysisService analysisServiceImpl,
-      @NonNull FileService fileService) {
+      @NonNull AnalysisService analysisServiceImpl) {
     this.songServerId = songServerId;
     this.sender = sender;
     this.internalAnalysisService = analysisServiceImpl;
-    this.fileService = fileService;
   }
 
   /** Decorated methods */

--- a/song-server/src/test/java/bio/overture/song/server/service/AnalysisServiceSenderTest.java
+++ b/song-server/src/test/java/bio/overture/song/server/service/AnalysisServiceSenderTest.java
@@ -5,7 +5,6 @@ import static bio.overture.song.core.model.enums.AnalysisStates.UNPUBLISHED;
 import static bio.overture.song.core.utils.JsonUtils.toJson;
 import static bio.overture.song.core.utils.RandomGenerator.createRandomGenerator;
 import static bio.overture.song.server.kafka.AnalysisMessage.createAnalysisMessage;
-import static bio.overture.song.server.utils.generator.AnalysisGenerator.createAnalysisGenerator;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
@@ -19,7 +18,6 @@ import bio.overture.song.server.model.dto.Payload;
 import bio.overture.song.server.model.entity.AnalysisSchema;
 import bio.overture.song.server.service.analysis.AnalysisService;
 import bio.overture.song.server.service.analysis.AnalysisServiceSender;
-import bio.overture.song.server.utils.generator.AnalysisGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -45,14 +43,11 @@ public class AnalysisServiceSenderTest {
 
   @Mock private AnalysisService internalAnalysisService;
 
-  @Mock private FileService fileService;
-
   /** State */
   private String studyId;
 
   private String analysisId;
 
-  private AnalysisGenerator analysisGenerator;
   private Analysis analysis;
 
   @Before
@@ -60,7 +55,6 @@ public class AnalysisServiceSenderTest {
     this.studyId = RANDOM_GENERATOR.generateRandomAsciiString(10);
     this.analysisId = RANDOM_GENERATOR.generateRandomUUIDAsString();
 
-    analysisGenerator = createAnalysisGenerator(studyId, internalAnalysisService, RANDOM_GENERATOR);
     val analysisSchema =
         AnalysisSchema.builder()
             .name("test-schema")
@@ -113,7 +107,7 @@ public class AnalysisServiceSenderTest {
 
   private AnalysisServiceSender createTestAnalysisServiceSender(AnalysisActions action) {
     val sender = createTestSender(action);
-    return new AnalysisServiceSender(SONG_ID, sender, internalAnalysisService, fileService);
+    return new AnalysisServiceSender(SONG_ID, sender, internalAnalysisService);
   }
 
   private TestSender createTestSender(AnalysisActions action) {


### PR DESCRIPTION
<!-- PR Title Should match format:
#{TicketNumber}: Description of Changes

if no ticket number, use `chore:`, `fix:`, `feat:` etc.

Example:
#123: Add pagination to List Applications endpoint
-->

## Summary

The focus of this work is to standardize the setup of request authorization requirements. This will make access too all controllers require authorization by default, with individual exceptions where required. For most Song controllers this means permitting GET requests and requiring auth for all others. This will also remove the requirement for an Authorization header from all request declarations so that missing authorization is treated  as Forbidden and not Malformed request.

To support this change, the Swagger documentation is being updated to include a Bearer Auth token security scheme that will let the user set their Authorization header once and apply that value to all requests.

This refactor will not change any access rules to any of the existing endpoints.

## Description of Changes
- SwaggerConfig
   - Add Bearer Token security scheme to page, so that the authorization header can be set once and applied to all requests, instead of set for each individual request
- SecurityConfig
   - /studies and /schemas endpoints are permitted for all GET requests but require auth for other HTTP verbs
- Controllers
   - All requests that previously state a required header for Authorization have had this removed, the security config and auth annotations will enforce authorization header existence.

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [x] **Formatting**
  - Code follows the project style guide
  - Autmated code formatters (ie. Prettier) have been run
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
