### PR TITLE
Fetch samples structure using batch JOIN query

### DIFF
--- a/data-migration/Dockerfile
+++ b/data-migration/Dockerfile
@@ -1,0 +1,86 @@
+# Global variables
+ARG COMMIT=""
+ARG APP_USER=data-migration
+ARG WORKDIR=/usr/src/app
+
+######################
+# Configure base image
+######################
+FROM node:24-alpine AS base
+
+ARG APP_USER
+ARG WORKDIR
+
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+
+# install pnpm as root user, before updating node ownership
+RUN npm i -g pnpm
+
+# create our own user to run node, don't run node in production as root
+ENV APP_UID=9999
+ENV APP_GID=9999
+RUN addgroup -S -g $APP_GID $APP_USER \
+	&& adduser -S -u $APP_UID -g $APP_GID $APP_USER \
+	&& mkdir -p ${WORKDIR}
+
+WORKDIR ${WORKDIR}
+
+RUN chown -R ${APP_USER}:${APP_USER} ${WORKDIR}
+
+USER ${APP_USER}:${APP_USER}
+
+######################
+# Configure build image
+######################
+
+FROM base as build
+
+ARG APP_USER
+ARG WORKDIR
+
+COPY --chown=${APP_USER}:${APP_USER} . ./
+
+RUN pnpm install --ignore-scripts
+
+RUN pnpm build
+
+
+######################
+# Configure prod-deps image
+######################
+
+FROM build AS prod-deps
+
+ARG APP_USER
+ARG WORKDIR
+
+WORKDIR ${WORKDIR}
+
+USER ${APP_USER}:${APP_USER}
+
+# pnpm will not install any package listed in devDependencies
+RUN pnpm install --prod
+
+
+######################
+# Configure server image
+######################
+FROM base AS server
+
+ARG APP_USER
+ARG WORKDIR
+
+USER ${APP_USER}
+
+WORKDIR ${WORKDIR}
+
+COPY --from=prod-deps ${WORKDIR}/node_modules ./node_modules
+COPY --from=build ${WORKDIR}/dist .
+
+EXPOSE 3000
+
+ENV COMMIT_SHA=${COMMIT}
+ENV NODE_ENV=production
+
+CMD [ "pnpm", "start" ]

--- a/data-migration/Dockerfile
+++ b/data-migration/Dockerfile
@@ -83,4 +83,4 @@ EXPOSE 3000
 ENV COMMIT_SHA=${COMMIT}
 ENV NODE_ENV=production
 
-CMD [ "pnpm", "start" ]
+CMD [ "node", "index.js" ]

--- a/data-migration/Dockerfile
+++ b/data-migration/Dockerfile
@@ -39,7 +39,7 @@ FROM base as build
 ARG APP_USER
 ARG WORKDIR
 
-COPY --chown=${APP_USER}:${APP_USER} . ./
+COPY --chown=${APP_USER}:${APP_USER} ./data-migration ./
 
 RUN pnpm install --ignore-scripts
 

--- a/data-migration/package.json
+++ b/data-migration/package.json
@@ -3,9 +3,10 @@
   "version": "1.0.0",
   "description": "Data migration for Song 5.3.x",
   "main": "src/index.ts",
-  "type": "module",
   "scripts": {
+    "build": "tsc",
     "dev": "tsx src/index.ts",
+    "start": "node dist/index.js",
     "lint": "eslint .",
     "lint:fix": "eslint --fix ."
   },

--- a/data-migration/src/migration/migrate.ts
+++ b/data-migration/src/migration/migrate.ts
@@ -1,6 +1,6 @@
 import { pool } from '../config/db';
 import { env } from '../config/env';
-import type { Analysis, UpdateAnalysesResult } from '../types';
+import type { AnalysisData, UpdateAnalysesResult } from '../types';
 import { getSamplesStructureForAnalyses } from './samplesStructureForAnalyses.js';
 import { updateAnalyses } from './updateAnalyses';
 
@@ -26,9 +26,9 @@ const getAllStudies = async (): Promise<
  * @param offset
  * @returns
  */
-const getAnalysesFromStudy = async (studyId: string, limit: number, offset: number): Promise<Analysis[]> => {
+const getAnalysesFromStudy = async (studyId: string, limit: number, offset: number): Promise<AnalysisData[]> => {
 	const analysisRes = await pool.query(
-		'SELECT * FROM analysis WHERE study_id = $1 ORDER BY created_at ASC LIMIT $2 OFFSET $3',
+		'SELECT id, analysis_data_id FROM analysis WHERE study_id = $1 ORDER BY created_at ASC LIMIT $2 OFFSET $3',
 		[studyId, limit, offset],
 	);
 
@@ -51,10 +51,11 @@ export const migrateData = async (): Promise<void> => {
 			let offset = 0;
 			let studyAnalysisCount = 0;
 			const failedAnalyses: UpdateAnalysesResult[] = [];
-			const successAnalysis: UpdateAnalysesResult[] = [];
 			console.log(`[${study.id}]:`, `Starting fetching analysis`);
 
 			while (true) {
+				const startDate = Date.now();
+
 				// Paginate analysis
 				const analyses = await getAnalysesFromStudy(study.id, limit, offset);
 
@@ -74,15 +75,17 @@ export const migrateData = async (): Promise<void> => {
 					failedAnalyses.push(...failed);
 				}
 
-				const success = updateResult.filter((result) => result.success);
-				if (success.length > 0) {
-					successAnalysis.push(...success);
-				}
+				const endDate = Date.now();
+				console.log(
+					`[${study.id}]:`,
+					`Processed ${analyses.length} analyses to get samples, donors and specimen in ${
+						endDate - startDate
+					} milliseconds`,
+				);
 
 				offset += limit;
 			}
 
-			// console.log(`[${study.id}]:`, `Successfully processed ${studyAnalysisCount} analyses`);
 			if (failedAnalyses.length > 0) {
 				console.error(`[${study.id}]:`, `Failed to update ${failedAnalyses.length} analyses`);
 				failedAnalyses.forEach((result) => {
@@ -92,7 +95,7 @@ export const migrateData = async (): Promise<void> => {
 				console.log(`[${study.id}]:`, `All analyses updated successfully`);
 			}
 
-			console.log(`[${study.id}]:`, `Finished migrating '${studyAnalysisCount}' analysis`);
+			console.log(`[${study.id}]:`, `Finished migrating '${studyAnalysisCount}' analyses`);
 			totalAnalysisCount += studyAnalysisCount;
 		}
 

--- a/data-migration/src/migration/migrate.ts
+++ b/data-migration/src/migration/migrate.ts
@@ -28,7 +28,7 @@ const getAllStudies = async (): Promise<
  */
 const getAnalysesFromStudy = async (studyId: string, limit: number, offset: number): Promise<AnalysisData[]> => {
 	const analysisRes = await pool.query(
-		'SELECT id, analysis_data_id FROM analysis WHERE study_id = $1 ORDER BY created_at ASC LIMIT $2 OFFSET $3',
+		'SELECT id, analysis_data_id FROM analysis WHERE study_id = $1 ORDER BY created_at, updated_at ASC LIMIT $2 OFFSET $3',
 		[studyId, limit, offset],
 	);
 

--- a/data-migration/src/migration/samplesStructureForAnalyses.ts
+++ b/data-migration/src/migration/samplesStructureForAnalyses.ts
@@ -1,138 +1,96 @@
 import { pool } from '../config/db';
-import type { Analysis, AnalysisSamplesMapping, Donor, Sample, Specimen } from '../types';
+import type { AnalysisData, AnalysisSamplesMapping, Donor, Sample, Specimen } from '../types';
 
 /**
- * Fetches all samples associated with a specific analysis ID.
- * @param analysisId Analysis ID to fetch samples for
- * @returns
+ * Retrieves the samples structure for a list of analyses using a single batch JOIN query.
+ * @param analysisList An array of Analysis objects to be processed
+ * @returns A mapping of analysis_data_id to an array of Sample objects
  */
-const fetchSamplesSpecimenDonorsForAnalysis = async (analysisId: string): Promise<Sample[]> => {
-	const sampleIds = await getSampleIdsForAnalysis(analysisId);
+const getSamplesStructureForAnalyses = async (analysisList: AnalysisData[]): Promise<AnalysisSamplesMapping> => {
+	if (analysisList.length === 0) {
+		return {};
+	}
 
-	const samples: Sample[] = [];
-	for (const sampleId of sampleIds) {
-		const sampleRow = await getSamplesById(sampleId);
-		if (!sampleRow) {
-			continue;
-		}
+	// Build a lookup from analysis.id → analysis_data_id so we can group results below
+	const analysisIdToDataId = new Map(analysisList.map(({ id, analysis_data_id }) => [id, analysis_data_id]));
+	const analysisIds = analysisList.map((a) => a.id);
 
-		const specimenRow = await getSpecimenById(sampleRow.specimen_id);
-		if (!specimenRow) {
+	const result = await pool.query<{
+		analysis_id: string;
+		sample_id: string;
+		sample_submitter_id: string;
+		sample_type: string;
+		matched_normal_submitter_sample_id: string | null;
+		specimen_id: string;
+		specimen_type: string;
+		specimen_submitter_id: string;
+		tumour_normal_designation: string;
+		specimen_tissue_source: string;
+		donor_id: string;
+		donor_submitter_id: string;
+		gender: string;
+	}>(
+		`SELECT
+			ss.analysis_id,
+			sa.id                                AS sample_id,
+			sa.submitter_id                      AS sample_submitter_id,
+			sa.type                              AS sample_type,
+			sa.matched_normal_submitter_sample_id,
+			sp.id                                AS specimen_id,
+			sp.type                              AS specimen_type,
+			sp.submitter_id                      AS specimen_submitter_id,
+			sp.tumour_normal_designation,
+			sp.tissue_source                     AS specimen_tissue_source,
+			d.id                                 AS donor_id,
+			d.submitter_id                       AS donor_submitter_id,
+			d.gender
+		FROM sampleset ss
+		JOIN sample   sa ON ss.sample_id   = sa.id
+		JOIN specimen sp ON sa.specimen_id = sp.id
+		JOIN donor    d  ON sp.donor_id    = d.id
+		WHERE ss.analysis_id = ANY($1)`,
+		[analysisIds],
+	);
+
+	// Pre-initialise mapping with empty arrays so analyses with no samples are still present
+	const mapping: AnalysisSamplesMapping = {};
+	for (const { analysis_data_id } of analysisList) {
+		mapping[analysis_data_id] = [];
+	}
+
+	for (const row of result.rows) {
+		const analysisDataId = analysisIdToDataId.get(row.analysis_id);
+		if (analysisDataId === undefined) {
 			continue;
 		}
 
 		const specimen: Specimen = {
-			specimenId: specimenRow.id,
-			specimenType: specimenRow.type,
-			submitterSpecimenId: specimenRow.submitter_id,
-			tumourNormalDesignation: specimenRow.tumour_normal_designation,
-			specimenTissueSource: specimenRow.tissue_source,
+			specimenId: row.specimen_id,
+			specimenType: row.specimen_type,
+			submitterSpecimenId: row.specimen_submitter_id,
+			tumourNormalDesignation: row.tumour_normal_designation,
+			specimenTissueSource: row.specimen_tissue_source,
 		};
 
-		const donorRow = await getDonorById(specimenRow.donor_id);
-		if (!donorRow) {
-			continue;
-		}
-
 		const donor: Donor = {
-			donorId: donorRow.id,
-			submitterDonorId: donorRow.submitter_id,
-			gender: donorRow.gender,
+			donorId: row.donor_id,
+			submitterDonorId: row.donor_submitter_id,
+			gender: row.gender,
 		};
 
 		const sample: Sample = {
-			sampleId: sampleRow.id,
-			submitterSampleId: sampleRow.submitter_id,
-			sampleType: sampleRow.type,
-			matchedNormalSubmitterSampleId: sampleRow.matched_normal_submitter_sample_id,
+			sampleId: row.sample_id,
+			submitterSampleId: row.sample_submitter_id,
+			sampleType: row.sample_type,
+			matchedNormalSubmitterSampleId: row.matched_normal_submitter_sample_id,
 			specimen,
 			donor,
 		};
 
-		samples.push(sample);
+		mapping[analysisDataId].push(sample);
 	}
-	return samples;
-};
 
-/**
- * Retrieves a Donor object from the databse by its ID
- * @param donorId
- * @param specimen
- * @returns
- */
-const getDonorById = async (
-	donorId: string,
-): Promise<{ id: string; study_id: string; submitter_id: string; gender: string } | null> => {
-	const result = await pool.query('SELECT * FROM donor WHERE id = $1', [donorId]);
-	return result.rows[0];
-};
-
-/**
- * Retrieves the samples structure for a list of analyses.
- * @param analysisList An array of Analysis objects to be processed
- * @returns A mapping of analysis_data_id to an array of Sample objects
- */
-const getSamplesStructureForAnalyses = async (analysisList: Analysis[]): Promise<AnalysisSamplesMapping> => {
-	// entries will be an array of tuples [number, Sample[]]
-	const entries: [number, Sample[]][] = await Promise.all(
-		analysisList.map(async ({ id, analysis_data_id }) => {
-			const samples = await fetchSamplesSpecimenDonorsForAnalysis(id);
-			return [analysis_data_id, samples];
-		}),
-	);
-
-	return Object.fromEntries(entries);
-};
-
-/**
- * Retrieves a sample object from the database by its ID
- * @param sampleId
- * @returns
- */
-const getSamplesById = async (
-	sampleId: string,
-): Promise<{
-	id: string;
-	specimen_id: string;
-	submitter_id: string;
-	legacy_type: string;
-	type: string;
-	matched_normal_submitter_sample_id: string;
-} | null> => {
-	const sampleRes = await pool.query('SELECT * FROM sample WHERE id = $1', [sampleId]);
-	return sampleRes.rows[0];
-};
-
-/**
- * Get all sample IDs for an analysis
- * @param analysisId
- * @returns
- */
-const getSampleIdsForAnalysis = async (analysisId: string): Promise<string[]> => {
-	// 'sampleset' table maps the analysis_id with sample_id
-	const result = await pool.query('SELECT sample_id FROM sampleset WHERE analysis_id = $1', [analysisId]);
-	return result.rows.map((row) => row.sample_id);
-};
-
-/**
- * Retrieves a specimen object from the database by its ID
- * @param specimenId
- * @returns
- */
-const getSpecimenById = async (
-	specimenId: string,
-): Promise<{
-	id: string;
-	donor_id: string;
-	submitter_id: string;
-	class: string;
-	legacy_type: string;
-	tissue_source: string;
-	tumour_normal_designation: string;
-	type: string;
-} | null> => {
-	const specimenRes = await pool.query('SELECT * FROM specimen WHERE id = $1', [specimenId]);
-	return specimenRes.rows[0];
+	return mapping;
 };
 
 export { getSamplesStructureForAnalyses };

--- a/data-migration/src/migration/updateAnalyses.ts
+++ b/data-migration/src/migration/updateAnalyses.ts
@@ -18,7 +18,7 @@ export const updateAnalyses = async (samplesMapping: AnalysisSamplesMapping) => 
 			]);
 
 			if (resultUpdate.rowCount === 0) {
-				console.log(`No rows updated for Analysis Data ID: "${analysisDataId}".`);
+				console.error(`No rows updated for Analysis Data ID: "${analysisDataId}".`);
 			}
 
 			return { analysisDataId, success: (resultUpdate.rowCount || 0) > 0 };

--- a/data-migration/src/types/index.ts
+++ b/data-migration/src/types/index.ts
@@ -38,4 +38,6 @@ export type Analysis = {
 	updated_at: string;
 };
 
+export type AnalysisData = Pick<Analysis, 'id' | 'analysis_data_id'>;
+
 export type AnalysisSamplesMapping = Record<number, Sample[]>;

--- a/pom.xml
+++ b/pom.xml
@@ -358,8 +358,8 @@
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-core</artifactId>
-                <version>1.3</version>
+                <artifactId>hamcrest</artifactId>
+                <version>2.2</version>
                 <scope>test</scope>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -356,6 +356,12 @@
                 <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+                <version>1.3</version>
+                <scope>test</scope>
+            </dependency>
 
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -356,12 +356,6 @@
                 <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest</artifactId>
-                <version>2.2</version>
-                <scope>test</scope>
-            </dependency>
 
         </dependencies>
     </dependencyManagement>

--- a/song-client/pom.xml
+++ b/song-client/pom.xml
@@ -99,6 +99,11 @@
 			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/song-core/pom.xml
+++ b/song-core/pom.xml
@@ -92,8 +92,13 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<scope>compile</scope>
+			<scope>provided</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 
 </project>

--- a/song-core/pom.xml
+++ b/song-core/pom.xml
@@ -92,7 +92,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<scope>provided</scope>
+			<scope>compile</scope>
 		</dependency>
 	</dependencies>
 

--- a/song-java-sdk/pom.xml
+++ b/song-java-sdk/pom.xml
@@ -85,6 +85,11 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
 		<dependency>
 			<groupId>com.github.tomakehurst</groupId>
 			<artifactId>wiremock</artifactId>


### PR DESCRIPTION
# Description
This PR makes some changes to the Analysis Samples migration script.

## Changes:
- It replaces 3 individual queries (getSamplesById, getSpecimenById, getDonorById) with 1 single batch JOIN query.
- Added a Dockerfile to build a Docker image